### PR TITLE
1.10.3F

### DIFF
--- a/addons-page1.opy
+++ b/addons-page1.opy
@@ -32,8 +32,7 @@ rule "Addon | AFK timer":
     if eventPlayer.checkpoint_notLast and not eventPlayer.toggle_invincible:
         CheckpointFailReset()
 
-    if RULE_CONDITION:
-        goto RULE_START
+    if RULE_CONDITION: goto RULE_START
 
 rule "Addon | Pre-set control map portal - toggled via workshop":
     @Event eachPlayer

--- a/addons-page1.opy
+++ b/addons-page1.opy
@@ -233,7 +233,6 @@ def AddonCheckMap():
     createDummy(Hero.ANA, Team.1 if getNumberOfSlots(Team.1) < getNumberOfSlots(Team.2) else Team.2, -1, CheckpointPositions[0], null)
     MapChecker = getLastCreatedEntity()
     MapChecker.disableEnvironmentCollision(false)
-    MapChecker.disablePlayerCollision()
     MapChecker.setStatusEffect(null, Status.PHASED_OUT, Math.INFINITY)
     MapChecker.setInvisibility(Invis.ALL)
     MapChecker.startScalingSize(cpcircleradius / 0.45, false)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -48,7 +48,7 @@ rule "Addon | Title Data - 标题数据 <---- EDIT ME / 在此处编辑":
     @Disabled
     # enable this rule and fill in the title data below.
     # 启用此规则 并填写下面 的标题数据
-    wait(LoadOrder.addon_title)
+    wait(LoadOrder.addon)
     # checkpoint number
     # 每关数量
     TitleData[0] = [
@@ -110,7 +110,7 @@ rule "Addon | HUD text for certain Checkpoints - 特定关卡显示的HUD文本 
     @Disabled
     # the example fill shows a text for cp 1 and cp 3
     # 示例已填写 关卡1和3 的hud文本
-    wait(LoadOrder.addon_hud)
+    wait(LoadOrder.addon)
     # in CpHudText fill in text
     # 修改字符串 “CpHudText” 为顶部显示 的hud文本
     CpHudText = ["text cp 1","text cp 3"]
@@ -122,7 +122,7 @@ rule "Addon | Inworld text for certain Checkpoints - 特定关卡显示的地图
     @Disabled
     # the example fill shows a text for cp 1 and cp 3
     # 示例已填写 关卡1和3 的地图文本
-    wait(LoadOrder.addon_iwt)
+    wait(LoadOrder.addon)
     # in CpIwtText fill in text
     # 修改字符串 “CpIwtText” 为关卡显示 的地图文本
     CpIwtText = ["text cp 1","text cp 3"]
@@ -140,7 +140,7 @@ rule "Addon | Hint text for certain Checkpoints - 特定关卡的提示文本 <-
     @Disabled
     # the example fill shows a text for cp 1 and cp 3
     # 示例已填写 关卡1和3 的提示文本
-    wait(LoadOrder.addon_hint)
+    wait(LoadOrder.addon)
     # in HintText fill in text
     # 修改字符串 “HintText” 为关卡显示 的提示文本
     HintText = ["text cp 1","text cp 3"]

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -278,7 +278,7 @@ rule "Addon | Group Up":
 
     eventPlayer.startForcingPosition(CheckpointPositions[eventPlayer.checkpoint_current + 1] + 0.1 * Vector.UP, false)
     eventPlayer.setStatusEffect(null, Status.ROOTED, 0.3)
-    wait()
+    wait(7 * 0.016)
     eventPlayer.stopForcingPosition()
 
 def AddonCustomLoadAndReset():
@@ -323,26 +323,21 @@ rule "Addon | Fake Triple Jump - 假三段跳":
     @Disabled
     @Event eachPlayer
     @Hero genji
-    #Method D
-    #Updated Script by LulledLion 9-1-24
     @Condition BanTriple == false
     @Condition eventPlayer.isOnGround() == false
     @Condition eventPlayer.skill_usedDouble == false #Double cannot be used already
     @Condition eventPlayer.isHoldingButton(Button.RELOAD) == false #Don't trigger on reset
     eventPlayer.addon_enableDoubleChecks = true #Enable checking double jump
     wait()
-    if RULE_CONDITION:
-        goto RULE_START
-    if eventPlayer.skill_usedDouble:
+    if RULE_CONDITION: goto RULE_START
+    if eventPlayer.skill_usedDouble or eventPlayer.isHoldingButton(Button.RELOAD):
         return
     #Input window to Triple
-    waitUntil(eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD), 0.048)
-    #Cancel Triple
-    if eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD) or eventPlayer.hasStatusEffect(Status.ROOTED):
-        return
-    #Apply fake triple jump
+    waitUntil(eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP), 0.048)
     if eventPlayer.isHoldingButton(Button.JUMP) and eventPlayer.isJumping():
         eventPlayer.applyImpulse(Vector.UP, 9, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
+    else:
+        if RULE_CONDITION: goto RULE_START
 
 rule "Addon | fisho cp cheat for overpy toggle":
     @Event eachPlayer
@@ -353,11 +348,10 @@ rule "Addon | fisho cp cheat for overpy toggle":
     @Condition eventPlayer.toggle_practice == false
 
     if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        eventPlayer.teleport(CheckpointPositions[eventPlayer.checkpoint_current - 1])
         eventPlayer.checkpoint_current -= 1
     else:
         eventPlayer.checkpoint_current += 1
-        eventPlayer.teleport(CheckpointPositions[eventPlayer.checkpoint_current])
+    CheckpointFailReset()
 
 rule "Addon | Ledge Grab Patch v1.5":
     # Obsolete for OW v2.12

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -131,7 +131,7 @@ rule "Addon | Inworld text for certain Checkpoints - 特定关卡显示的地图
     CpIwtCp = [1, 3]
     # in CpIwtPos fill in the vector
     # 修改数组 “CpIwtPos” 为地图文本 的矢量位置
-    CpIwtPos = [vect(0,0,0), vect(0,0,0)]
+    CpIwtPos = [vect(1,1,1), vect(1,1,1)]
     # color applies to all
     # 选择应用到 所有地图文 本的颜色
     CpIwtColor = Color.LIME_GREEN
@@ -228,19 +228,13 @@ rule "Addon | Group up - Map Data":
         [i for i in getAllPlayers() if i.checkpoint_current == 777],
         "{0} {1} {0}".format(
             abilityIconString(Hero.GENJI, Button.ULTIMATE),
-            "待在这里" checkCN "group up"
-            ),
-        vect(0,0,0),
-        1.5,
-        Clip.NONE, WorldTextReeval.VISIBILITY_AND_STRING, Color.ORANGE, SpecVisibility.DEFAULT
-    )
+            "待在这里" checkCN "group up"),
+        vect(1,1,1), 1.5, Clip.NONE, WorldTextReeval.VISIBILITY_AND_STRING, Color.ORANGE, SpecVisibility.DEFAULT)
     # replace 777 with checkpoint number
     # replace vector 0,0,0 with orb position
     # 3.5 is the radius
-    createEffect(
-        [i for i in getAllPlayers() if i.checkpoint_current == 777],
-        Effect.SPHERE, Color.ORANGE, vect(0,0,0),  3.5, EffectReeval.VISIBILITY
-    )
+    createEffect([i for i in getAllPlayers() if i.checkpoint_current == 777],
+        Effect.SPHERE, Color.ORANGE, vect(1,1,1),  3.5, EffectReeval.VISIBILITY)
 
 rule "Addon | Group Up":
     @Disabled
@@ -252,7 +246,7 @@ rule "Addon | Group Up":
     @Condition eventPlayer.toggle_invincible == false
     # replace vector 0,0,0 with orb position
     # 3.5 is the radius
-    @Condition distance(eventPlayer, vect(0,0,0)) < 3.5
+    @Condition distance(eventPlayer, vect(1,1,1)) < 3.5
 
     smallMessage(eventPlayer, "   stay in the bubble")
     wait(1, Wait.ABORT_WHEN_FALSE)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -375,8 +375,8 @@ rule "Addon | Ledge Grab Patch v1.5":
             eventPlayer.startForcingButton(Button.JUMP)
             wait(false)
             eventPlayer.stopForcingButton(Button.JUMP)
-        waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or eventPlayer.isHoldingButton(Button.JUMP), Math.INFINITY)
-        waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or not eventPlayer.isHoldingButton(Button.JUMP), Math.INFINITY)
+        waitUntil(not eventPlayer.isInAir() or eventPlayer.isHoldingButton(Button.JUMP), Math.INFINITY)
+        waitUntil(not (eventPlayer.isInAir() and eventPlayer.isHoldingButton(Button.JUMP)), Math.INFINITY)
         #Create cBhop
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.064)
 

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -204,28 +204,22 @@ rule "Addon | Fake Ledge Dash - 超级跳":
     #爬墙/扒 > 长按跳 > 抓住窗台 > SHIFT > 等待发射 > 释放跳跃
 
     eventPlayer.addon_ledgeDash[0] = 0
-    waitUntil(eventPlayer.getSpeed() >= 45, 0.4)
-
-    while eventPlayer.isUsingAbility1() and eventPlayer.addon_ledgeDash[0] <= 12:
-        eventPlayer.addon_ledgeDash[1] = eventPlayer.getFacingDirection()
-        eventPlayer.addon_ledgeDash[2] = eventPlayer.getSpeed()
+    waitUntil(eventPlayer.getSpeed() >= 45, 25 * 0.016)
+    while eventPlayer.isUsingAbility1() and eventPlayer.addon_ledgeDash[0] < 12: # stop storing, we keep this speed/direction
         if eventPlayer.getSpeed() < 45: # dashed into air or object = end
             goto lbl_a
-        else:
-            eventPlayer.addon_ledgeDash[0] ++
-        if eventPlayer.addon_ledgeDash[0] == 12: # stop storing, we keep this speed/direction
-            waitUntil(eventPlayer.getSpeed() < 40, 0.4) # wait for dash to finish to execute
+        eventPlayer.addon_ledgeDash[0] ++
+        eventPlayer.addon_ledgeDash[1] = eventPlayer.getFacingDirection()
+        eventPlayer.addon_ledgeDash[2] = eventPlayer.getSpeed()
         wait()
-
+    waitUntil(eventPlayer.getSpeed() < 40, 25 * 0.016) # wait for dash to finish to execute
     if eventPlayer.addon_ledgeDash[0] >= 5: #and eventPlayer.addon_ledgeDash[0] <= 12: # ledge dash execute
         eventPlayer.applyImpulse(eventPlayer.addon_ledgeDash[1], eventPlayer.addon_ledgeDash.last(), Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
     # above 12 - climbed to long
     # below 5 - dashed into object
 
     lbl_a:
-    eventPlayer.addon_ledgeDash[0] = null
-    eventPlayer.addon_ledgeDash[1] = null
-    eventPlayer.addon_ledgeDash[2] = null
+    eventPlayer.addon_ledgeDash = null
 
 rule "Addon | Group up - Map Data":
     @Disabled

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -322,7 +322,7 @@ rule "Addon | Fake Triple Jump - 假三段跳":
     @Disabled
     @Event eachPlayer
     @Hero genji
-    @Condition BanTriple == false
+    #@Condition BanTriple == false
     @Condition eventPlayer.isOnGround() == false
     @Condition eventPlayer.skill_usedDouble == false #Double cannot be used already
     @Condition eventPlayer.isHoldingButton(Button.RELOAD) == false #Don't trigger on reset

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -189,8 +189,7 @@ rule "Addon | Stall enhancer - 增强系統跳的判定":
     eventPlayer.setMoveSpeed(100)
     if eventPlayer.isAlive() and not (eventPlayer.editor_fly or eventPlayer.isHoldingButton(Button.RELOAD)):
         eventPlayer.applyImpulse(Vector.UP, 10, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
-        if RULE_CONDITION:
-            goto RULE_START
+        if RULE_CONDITION: goto RULE_START
 
 # dash after ledge grab
 # stores speed and launches you after dash if you done it during climb

--- a/commands.opy
+++ b/commands.opy
@@ -56,7 +56,7 @@ rule "Command | Preview Orbs & Portals (Hold Primary + Secondary)":
     @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
     #wait(0.9, Wait.ABORT_WHEN_FALSE)
     wait(0.45, Wait.ABORT_WHEN_FALSE)
-    eventPlayer.preview_array1 = CheckpointPositions[eventPlayer.checkpoint_current + 1][0]
+    eventPlayer.preview_array1 = [CheckpointPositions[eventPlayer.checkpoint_current + 1][0]]
     if len(BouncePadCheckpoints):
         eventPlayer.preview_array1.append([_ for _ , i in BouncePositions if BouncePadCheckpoints[i] == eventPlayer.checkpoint_current])
         eventPlayer.preview_array2.append([_ for _ in [i for _, i in BouncePadCheckpoints] if BouncePadCheckpoints[_] == eventPlayer.checkpoint_current])

--- a/commands.opy
+++ b/commands.opy
@@ -48,7 +48,8 @@ a few huds show/hides when reviewarray is not null !!!!!!!!!!!!!!!!!
 */
 rule "Command | Preview Orbs & Portals (Hold Primary + Secondary)":
     @Event eachPlayer
-    @Condition eventPlayer.editor_on == false
+    #@Condition eventPlayer.editor_on == false
+    @Condition eventPlayer.lockState == false
     @Condition eventPlayer.lockState == false
     @Condition eventPlayer.checkpoint_notLast
     @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)

--- a/commands.opy
+++ b/commands.opy
@@ -20,9 +20,9 @@ rule "Command | Split hide (Hold Dash + Primary + Secondary)":
     wait(1, Wait.ABORT_WHEN_FALSE)
 
     #smallMessage(eventPlayer, "   split display off" if eventPlayer.timer_splitDisplay != -Math.INFINITY else "   split display on")
-    eventPlayer.timer_splitDisplay = 0 if eventPlayer.timer_splitDisplay == -Math.INFINITY else -Math.INFINITY
+    eventPlayer.timer_splitDisplay = 0 if eventPlayer.timer_splitDisplay <= -Math.INFINITY else -Math.INFINITY
     playEffect(eventPlayer, DynamicEffect.BUFF_IMPACT_SOUND, Color.WHITE, eventPlayer, 100)
-    smallMessage(eventPlayer, "   split display off" if eventPlayer.timer_splitDisplay == -Math.INFINITY else "   split display on")
+    smallMessage(eventPlayer, "   split display off" if eventPlayer.timer_splitDisplay <= -Math.INFINITY else "   split display on")
     wait(0.32)
 
 rule "Command | Toggle Invisible (Hold Deflect)":
@@ -131,7 +131,7 @@ rule "Command | Restart Run (Crouch + Interact + Deflect)":
             CompAtmpSaveCount[CompAtmpSaveNames.index(eventPlayer[0].split([]))] = eventPlayer.comp_countAttempts
     eventPlayer.editor_fly = null
     eventPlayer.checkpoint_current = 0
-    eventPlayer.timer_splitDisplay = -Math.INFINITY if eventPlayer.timer_splitDisplay == -Math.INFINITY else 0 #$$ -Math.INFINITY * (eventPlayer.timer_splitDisplay == -Math.INFINITY)
+    eventPlayer.timer_splitDisplay = -Math.INFINITY * (eventPlayer.timer_splitDisplay <= -Math.INFINITY)
     eventPlayer.toggle_practice = false
     eventPlayer.timer_practice = 0
     stopChasingVariable(eventPlayer.timer_practice)
@@ -226,7 +226,7 @@ rule "Command | Toggle Practice Mode (Melee + Ultimate)":
         bigMessage(eventPlayer,"练习模式" checkCN "Practice mode")
         TimerPause()
         eventPlayer.checkpoint_practice = eventPlayer.checkpoint_current
-        eventPlayer.timer_splitDisplay = -Math.INFINITY if eventPlayer.timer_splitDisplay == -Math.INFINITY else 0 #$$ -Math.INFINITY * (eventPlayer.timer_splitDisplay == -Math.INFINITY)
+        eventPlayer.timer_splitDisplay = -Math.INFINITY * (eventPlayer.timer_splitDisplay <= -Math.INFINITY)
         eventPlayer.timer_split = 0
         eventPlayer.timer_practice = 0
         chase(eventPlayer.timer_practice, Math.INFINITY, rate=1, ChaseReeval.NONE)

--- a/definitions.opy
+++ b/definitions.opy
@@ -17,10 +17,10 @@ insert_array.append(insert_value)\
 insert_array = [e if i < insert_index else insert_array.last() if i == insert_index else insert_array[i - 1] for e, i in insert_array]
 
 #!define toggleCpInArray(baninput)\
-if eventPlayer.checkpoint_current in baninput:\
-    baninput.remove(eventPlayer.checkpoint_current)\
+if hostPlayer.checkpoint_current in baninput:\
+    baninput.remove(hostPlayer.checkpoint_current)\
 else:\
-    baninput.append(eventPlayer.checkpoint_current)
+    baninput.append(hostPlayer.checkpoint_current)
 
 #!define removeCPandLower(arrayname)\
 arrayname.remove(hostPlayer.checkpoint_current)\

--- a/definitions.opy
+++ b/definitions.opy
@@ -14,20 +14,18 @@
 
 #!define insert(insert_array, insert_index, insert_value)\
 insert_array.append(insert_value)\
-insert_array = [elementhere if i < insert_index else insert_array.last() if i == insert_index else insert_array[i - 1] for elementhere, i in insert_array]
-#$$ i != eventPlayer.checkpoint_current → i-eventPlayer.checkpoint_current
+insert_array = [e if i < insert_index else insert_array.last() if i == insert_index else insert_array[i - 1] for e, i in insert_array]
+
 #!define toggleCpInArray(baninput)\
 if eventPlayer.checkpoint_current in baninput:\
-    baninput = [i for i in baninput if i != eventPlayer.checkpoint_current]\
+    baninput.remove(eventPlayer.checkpoint_current)\
 else:\
     baninput.append(eventPlayer.checkpoint_current)
 
 #!define removeCPandLower(arrayname)\
-arrayname = [i for i in arrayname if i != hostPlayer.checkpoint_current]\
+arrayname.remove(hostPlayer.checkpoint_current)\
 arrayname = [x - (1 if x >= hostPlayer.checkpoint_current else 0) for x in arrayname]
 
-#!define LeftAlign32 "                                "
-#!define LeftAlign64 "                                                                "
 #!define LeftAlign96 "                                                                                                "
 #!define LeftAlign128 "                                                                                                                                "
 

--- a/definitions.opy
+++ b/definitions.opy
@@ -264,7 +264,7 @@ playervar preview_i                         # int                       --- prev
 playervar editor_on                          # bool                      --- on all players, but only gets checked from host player
 playervar editor_modeSelect                 # int                       --- EditMode - 1 checkpoint | 2 Killing sphere | 3 Bouncing ball
 playervar editor_fly                         # vector/null               --- null if not flying, else vector position, added by fisho
-playervar editor_saveHud                        # array                     --- array of save map hud ids
+playervar editor_saveCache                        # array                     --- array of save map hud ids
 playervar editor_undo
 playervar editor_lock                        # bool                      --- ensure only 1 editor command can go of at the time
 playervar editor_hitboxEffect

--- a/definitions.opy
+++ b/definitions.opy
@@ -217,7 +217,7 @@ playervar toggle_invisible                             # bool                   
 playervar toggle_hints
 
 playervar skill_countBhops                         # int                       --- counts bhops used for stand create ban
-playervar skill_countJumps                         # int                       --- jump tracking count, 0, 1, 2
+playervar skill_usedHop                         # int                       --- jump tracking count, 0, 1, 2
 playervar skill_countCreates
 playervar skill_countMulti                   # int                       --- climb count # for HUD
 playervar skill_usedClimb                     # bool                      --- turned into bool

--- a/definitions.opy
+++ b/definitions.opy
@@ -427,10 +427,10 @@ enum LoadOrder:
     portal      = LoadOrder.setup + 0.016 * 32,
     effects     = LoadOrder.portal + 0.016 * 32,
     hudsPlayer  = 0.016 * 32,
-    hudsGlobal  = 0.016 * 62.5,
-    addon_title = 0.016 * 62.5,
-    addon_hud   = 0.016 * 62.5,
-    addon_iwt   = 0.016 * 62.5,
-    addon_hint  = 0.016 * 62.5,
+    addon_title = 0.016 * 48,
+    addon_hud   = 0.016 * 48,
+    addon_iwt   = 0.016 * 48,
+    addon_hint  = 0.016 * 48,
+    hudsGlobal  = 0.016 * 63,
 
 

--- a/definitions.opy
+++ b/definitions.opy
@@ -305,7 +305,6 @@ subroutine EditorSelectLast
 subroutine AddonCustomLoadAndReset
 subroutine AddonCheckMap
 subroutine Addon3rdPerson
-subroutine EffectsCreate
 subroutine RebuildKillOrbs
 subroutine RebuildPortals
 subroutine RebuildBounceOrbs

--- a/definitions.opy
+++ b/definitions.opy
@@ -427,10 +427,7 @@ enum LoadOrder:
     portal      = LoadOrder.setup + 0.016 * 32,
     effects     = LoadOrder.portal + 0.016 * 32,
     hudsPlayer  = 0.016 * 32,
-    addon_title = 0.016 * 48,
-    addon_hud   = 0.016 * 48,
-    addon_iwt   = 0.016 * 48,
-    addon_hint  = 0.016 * 48,
-    hudsGlobal  = 0.016 * 63,
-
+    addon       = 0.016 * 48,
+    hudsGlobal  = 0.016 * 50,
+    hudsEditor  = 0.016 * 52,
 

--- a/editor.opy
+++ b/editor.opy
@@ -386,7 +386,7 @@ rule "Editor | Hud and Effects":
                 iconString(Icon.ARROW_RIGHT) if EditorMode.portal else "     ")
         if hostPlayer.isHoldingButton(Button.MELEE) else
             " {1} {0} ".format(
-                ["checkpoints" ,"boundary sphere","function orbs","skill bans","portals"][EditorMode.current],
+                ["checkpoints" ,"boundary spheres","function orbs","skill bans","portals"][EditorMode.current],
                 [iconString(Icon.FLAG), iconString(Icon.SKULL), iconString(Icon.MOON), iconString(Icon.STOP),iconString(Icon.SPIRAL)][EditorMode.current])
         if localPlayer == hostPlayer else
             " {0} Genji editor {0} ".format(iconString(Icon.BOLT)),
@@ -668,18 +668,18 @@ rule "Editor | change mode":
 
 def EditUpdateSelectedIds():
     @Name "Editor | update selected id"
-
+    #$$
     if EditorMode.killBall:
-        EditSelectIdArray  = [i for _, i in KillballCheckpoints]
-        EditSelectIdArray = [ i for i in EditSelectIdArray if KillballCheckpoints[i] == hostPlayer.checkpoint_current ]
+        EditSelectIdArray = [i for _, i in KillballCheckpoints]
+        EditSelectIdArray = [i for i in EditSelectIdArray if KillballCheckpoints[i] == hostPlayer.checkpoint_current ]
     elif EditorMode.functionOrb:
-        EditSelectIdArray  = [i for _, i in BouncePadCheckpoints]
-        EditSelectIdArray = [ i for i in EditSelectIdArray if BouncePadCheckpoints[i] == hostPlayer.checkpoint_current ]
+        EditSelectIdArray = [i for _, i in BouncePadCheckpoints]
+        EditSelectIdArray = [i for i in EditSelectIdArray if BouncePadCheckpoints[i] == hostPlayer.checkpoint_current ]
     elif EditorMode.portal:
-        EditSelectIdArray  = [i for _, i in CustomPortalCP]
+        EditSelectIdArray = [i for _, i in CustomPortalCP]
         EditSelectIdArray = [i for i in EditSelectIdArray if CustomPortalCP[i] < 0 or CustomPortalCP[i] == hostPlayer.checkpoint_current]
     else:
-        EditSelectIdArray  = []
+        EditSelectIdArray = []
 
 def EditorSelectLast():
     @Name "Editor | select last"
@@ -1155,7 +1155,7 @@ rule "Editor | move object":
         eventPlayer.addon_toggle3rdPov = false
     eventPlayer.editor_fly = null
 
-    waitUntil(not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) and eventPlayer.isHoldingButton(Button.ABILITY_2)), true)
+    waitUntil(not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.ABILITY_2)), true)
     #eventPlayer.disallowButton(Button.ULTIMATE)
     #eventPlayer.disallowButton(Button.JUMP)
     eventPlayer.setStatusEffect(null, Status.HACKED, Math.INFINITY)

--- a/editor.opy
+++ b/editor.opy
@@ -586,30 +586,28 @@ rule "Editor | Hud and Effects":
     wait(1)
     # effects ==========================================================================================================================================================================
     createInWorldText(
-        localPlayer if len(EditSelectIdArray) else null,
+        true if len(EditSelectIdArray) else null,
         "选中的实体" checkCN "selected",
         KillBallPositions[EditSelected] if EditorMode.killBall else
         BouncePositions[EditSelected] if EditorMode.functionOrb else
         CustomPortalStart[EditSelected] if EditorMode.portal else
         null,
-        1.2, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.ORANGE, SpecVisibility.DEFAULT
-    )
+        1.2, Clip.NONE, WorldTextReeval.VISIBILITY_AND_POSITION, Color.ORANGE, SpecVisibility.DEFAULT)
 
     createIcon(
-        localPlayer if len(EditSelectIdArray) else null,
+        true if len(EditSelectIdArray) else null,
         KillBallPositions[EditSelected] if EditorMode.killBall else
         BouncePositions[EditSelected] if EditorMode.functionOrb else
         CustomPortalStart[EditSelected] if EditorMode.portal else
         null,
         Icon.ARROW_DOWN,
-        IconReeval.VISIBILITY_AND_POSITION, Color.WHITE, true
-    )
+        IconReeval.VISIBILITY_AND_POSITION, Color.WHITE, true)
 
     # Purple sphere for teleport location
-    createEffect(localPlayer if len(CheckpointPositions[hostPlayer.checkpoint_current] ) > 1 and EditorMode.checkpoint else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.checkpoint_current][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    createEffect(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.checkpoint_current][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
 
     # Teleport text
-    createInWorldText(localPlayer if len(CheckpointPositions[hostPlayer.checkpoint_current] ) > 1 and EditorMode.checkpoint else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.checkpoint_current][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+    createInWorldText(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.checkpoint_current][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
 
     # normal cp if teleport
     createEffect(hostPlayer if CheckpointPositions[hostPlayer.checkpoint_current][1] and EditorMode.checkpoint else null, Effect.RING, Color.ORANGE, CheckpointPositions[hostPlayer.checkpoint_current][0], 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
@@ -662,13 +660,11 @@ rule "Editor | change mode":
     @Condition eventPlayer.editor_lock == false
 
     eventPlayer.editor_lock = true
-
     if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
         eventPlayer.editor_modeSelect += (5 - 1)
     else:
         eventPlayer.editor_modeSelect += 1
     eventPlayer.editor_modeSelect %= 5
-
     EditUpdateSelectedIds()
     EditorSelectLast()
     wait()
@@ -677,7 +673,6 @@ rule "Editor | change mode":
 
 def EditUpdateSelectedIds():
     @Name "Editor | update selected id"
-    #$$
     if EditorMode.killBall:
         EditSelectIdArray = [i for _, i in KillballCheckpoints]
         EditSelectIdArray = [i for i in EditSelectIdArray if KillballCheckpoints[i] == hostPlayer.checkpoint_current ]

--- a/editor.opy
+++ b/editor.opy
@@ -3,8 +3,8 @@ rule "<tx0C00000000001344> Editor <tx0C00000000001344>":
     @Delimiter
 
 rule "Editor | Clear Excess Data to Save Map":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition hostPlayer.isHoldingButton(Button.MELEE)
     @Condition hostPlayer.isHoldingButton(Button.INTERACT)
@@ -12,9 +12,8 @@ rule "Editor | Clear Excess Data to Save Map":
     #@Condition hostPlayer.editor_lock == false # !!! don't lock. always be sure data can be exported incase of a perma lock situation
     wait(1, Wait.ABORT_WHEN_FALSE)
     hostPlayer.editor_lock = true # doesnt matter thats its in pasta's because it wil be fixed on spawning
-    hostPlayer.editor_saveCache[0] = TimeRemaining
+    hostPlayer.editor_saveCache = [TimeRemaining, ColorConfig]
     TimeRemaining = null
-    hostPlayer.editor_saveCache[1] = ColorConfig
     ColorConfig = null
 
     CheckpointRings_Editing = null
@@ -135,7 +134,7 @@ rule "Editor | Hud and Effects":
         # clear variables if not in editor mode
         HudStoreEdit = null
         return
-    wait(2)
+    wait(1)
     #hostPlayer.editor_lock = true
     while len(HudStoreEdit): # remove unnesesary huds
         destroyHudText(HudStoreEdit[0])
@@ -622,7 +621,7 @@ rule "Editor |  Fly/Noclip Toggle":
     @Condition eventPlayer.editor_on
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_1)
     @Condition eventPlayer.editor_fly == null
-    @Condition EditorMoveItem == false
+    @Condition (EditorMoveItem and eventPlayer == hostPlayer) == false
     waitUntil(eventPlayer.isHoldingButton(Button.RELOAD) or not eventPlayer.isHoldingButton(Button.ABILITY_1), 0.7)
     if eventPlayer.isHoldingButton(Button.RELOAD) or not eventPlayer.isHoldingButton(Button.ABILITY_1):
         wait()
@@ -652,8 +651,8 @@ rule "Editor |  Fly/Noclip Toggle":
     wait(1)
 
 rule "Editor | change mode":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition hostPlayer.editor_lock == false
     @Condition hostPlayer.isHoldingButton(Button.MELEE)
@@ -691,7 +690,7 @@ def EditorSelectLast():
 
 rule "Editor | create cp/orb":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition hostPlayer.editor_lock == false
     @Condition EditorMode.current in [0,1,2,4]
@@ -802,7 +801,7 @@ rule "Editor | create cp/orb":
 
 rule "Editor | delete cp/orb/portal":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition hostPlayer.editor_lock == false
     @Condition hostPlayer.isHoldingButton(Button.INTERACT)
@@ -923,7 +922,7 @@ rule "Editor | delete cp/orb/portal":
 
 rule "Editor | toggle orb functions":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition EditorMode.functionOrb
     @Condition hostPlayer.editor_lock == false
@@ -946,7 +945,7 @@ rule "Editor | toggle orb functions":
 
 rule "Editor | orb radi/strength":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1,2]
     @Condition hostPlayer.editor_lock == false
@@ -966,8 +965,8 @@ rule "Editor | orb radi/strength":
     hostPlayer.editor_lock = false
 
 rule "Editor | select orb/portal":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1,2,4]
     @Condition hostPlayer.editor_lock == false
@@ -987,8 +986,8 @@ rule "Editor | select orb/portal":
 # checkpoint functions ==============================================================
 
 rule "Editor | cp size hitbox display":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition EditorMode.current == 0
     @Condition hostPlayer.isHoldingButton(Button.INTERACT)
@@ -1029,8 +1028,8 @@ rule "Editor | cp add/remove teleport":
     wait()
 
 rule "Editor | moving checkpoint":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition EditorMode.current == 0
     @Condition hostPlayer.editor_lock == false
@@ -1081,7 +1080,7 @@ rule "Editor | add ult/dash":
 
 rule "Editor | toggle bans":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition EditorMode.skillBan
     @Condition hostPlayer.editor_lock == false
@@ -1116,8 +1115,8 @@ rule "Editor | toggle bans":
     hostPlayer.editor_lock = false
 
 rule "Editor | portal cp change":
-    @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    #@Event eachPlayer
+    #@Condition eventPlayer == hostPlayer
     @Condition hostPlayer.editor_on
     @Condition EditorMode.portal
     @Condition hostPlayer.editor_lock == false
@@ -1130,7 +1129,7 @@ rule "Editor | portal cp change":
 
 rule "Editor | move object":
     @Event eachPlayer
-    @Condition eventPlayer == hostPlayer
+    @Condition eventPlayer == hostPlayer #Required for UpdateCache()
     @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1, 2, 4]
     @Condition hostPlayer.editor_lock == false

--- a/editor.opy
+++ b/editor.opy
@@ -12,8 +12,11 @@ rule "Editor | Clear Excess Data to Save Map":
     #@Condition eventPlayer.editor_lock == false # !!! don't lock. always be sure data can be exported incase of a perma lock situation
     wait(1, Wait.ABORT_WHEN_FALSE)
     eventPlayer.editor_lock = true # doesnt matter thats its in pasta's because it wil be fixed on spawning
-    eventPlayer.editor_saveHud = TimeRemaining
+    eventPlayer.editor_saveCache[0] = TimeRemaining
     TimeRemaining = null
+    eventPlayer.editor_saveCache[1] = ColorConfig
+    ColorConfig = null
+
     CheckpointRings_Editing = null
     KillBallEffects = null
     TempIterator1 = null
@@ -26,7 +29,6 @@ rule "Editor | Clear Excess Data to Save Map":
     #SavePauseTime = null
     #SavePauseEnabled = null
     SaveElapsed = null
-    ColorConfig = null
     CompMode = null
     LeaderBoardFull = null
     LeaderBoardHuds = null
@@ -106,23 +108,24 @@ rule "Editor | Clear Excess Data to Save Map":
         " ESC → SHOW LOBBY → SETTINGS → SHARE CODE →\n"
         " UPLOAD TO EXISTING CODE → PASTE THE CODE YOU CREATED IN STEP 4",
        HudPosition.TOP, HO.edit_clearec1, Color.LIME_GREEN,Color.LIME_GREEN,Color.LIME_GREEN, HudReeval.STRING, SpecVisibility.DEFAULT)
-    eventPlayer.editor_saveHud.append(getLastCreatedText())
+    eventPlayer.editor_saveCache[2]=getLastCreatedText()
 
     hudHeader(eventPlayer,
         "    > 按互动键关闭当前窗口 <    "
         checkCN
         "    > Press Interact to close this window <    "
         , HudPosition.TOP, HO.edit_clearec3, Color.LIME_GREEN, HudReeval.STRING)
-    eventPlayer.editor_saveHud.append(getLastCreatedText())
+    eventPlayer.editor_saveCache[3]=getLastCreatedText()
 
     enableInspector()
     disableInspector()
     waitUntil(not eventPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
     waitUntil(eventPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
-    TimeRemaining = eventPlayer.editor_saveHud[0]
-    destroyHudText(eventPlayer.editor_saveHud[1])
-    destroyHudText(eventPlayer.editor_saveHud.last())
-    eventPlayer.editor_saveHud = null
+    TimeRemaining = eventPlayer.editor_saveCache[0]
+    ColorConfig = eventPlayer.editor_saveCache[1]
+    destroyHudText(eventPlayer.editor_saveCache[2])
+    destroyHudText(eventPlayer.editor_saveCache.last())
+    eventPlayer.editor_saveCache = null
     eventPlayer.editor_lock = false
 
 rule "Editor | Hud and Effects":
@@ -356,7 +359,7 @@ rule "Editor | Hud and Effects":
         "to save map, hold {0} + {1} + {2} then follow instructions" LeftAlign96.format(buttonString(Button.INTERACT), buttonString(Button.MELEE), buttonString(Button.RELOAD)),
         HudPosition.LEFT, HO.edit_savemap, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    hudText(localPlayer if not localPlayer.editor_saveHud else null,
+    hudText(localPlayer if not localPlayer.editor_saveCache else null,
         (   "{0} 检查点模式\n"
             "{1} 击杀球模式\n"
             "{2} 弹球模式\n"

--- a/editor.opy
+++ b/editor.opy
@@ -637,7 +637,7 @@ rule "Editor |  Fly/Noclip Toggle":
     waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_1), true)
 
     while eventPlayer.isAlive() and eventPlayer.editor_fly and not eventPlayer.isHoldingButton(Button.ABILITY_1):
-        if not (eventPlayer == hostPlayer and EditorMoveItem):
+        if not (eventPlayer == hostPlayer and eventPlayer.editor_lock):
             eventPlayer.editor_fly += flyMovementDelta
         wait()
     
@@ -1068,7 +1068,7 @@ rule "Editor | moving checkpoint":
 
     eventPlayer.stopCamera()
     eventPlayer.setMoveSpeed(100)
-    if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+    if eventPlayer.isHoldingButton(Button.ABILITY_2):
         CheckpointPositions[eventPlayer.checkpoint_current] = eventPlayer.editor_undo
         waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_2), Math.INFINITY)
 
@@ -1156,13 +1156,14 @@ rule "Editor | move object":
     EditorMoveItem = true
     if eventPlayer.addon_toggle3rdPov:
         eventPlayer.addon_toggle3rdPov = false
-    eventPlayer.editor_fly = null
+    #eventPlayer.editor_fly = null
 
     waitUntil(not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.ABILITY_2)), true)
     #eventPlayer.disallowButton(Button.ULTIMATE)
     #eventPlayer.disallowButton(Button.JUMP)
     eventPlayer.setStatusEffect(null, Status.HACKED, Math.INFINITY)
-    eventPlayer.startForcingPosition(eventPlayer.getPosition(), false)
+    eventPlayer.setMoveSpeed(false)
+    #eventPlayer.startForcingPosition(eventPlayer.getPosition(), false)
     
     if EditorMode.killBall:
         eventPlayer.editor_undo = KillBallPositions[EditSelected]
@@ -1223,7 +1224,8 @@ rule "Editor | move object":
     #eventPlayer.allowButton(Button.JUMP)
     eventPlayer.clearStatusEffect(Status.HACKED)
     eventPlayer.stopCamera()
-    eventPlayer.stopForcingPosition()
+    eventPlayer.setMoveSpeed(100)
+    #eventPlayer.stopForcingPosition()
     EditorMoveItem = null
     UpdateCache()
     waitUntil(not eventPlayer.isHoldingButton(Button.PRIMARY_FIRE), true)

--- a/editor.opy
+++ b/editor.opy
@@ -4,17 +4,17 @@ rule "<tx0C00000000001344> Editor <tx0C00000000001344>":
 
 rule "Editor | Clear Excess Data to Save Map":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
-    @Condition eventPlayer.isHoldingButton(Button.MELEE)
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT)
-    @Condition eventPlayer.isHoldingButton(Button.RELOAD)
-    #@Condition eventPlayer.editor_lock == false # !!! don't lock. always be sure data can be exported incase of a perma lock situation
+    @Condition hostPlayer.editor_on
+    @Condition hostPlayer.isHoldingButton(Button.MELEE)
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT)
+    @Condition hostPlayer.isHoldingButton(Button.RELOAD)
+    #@Condition hostPlayer.editor_lock == false # !!! don't lock. always be sure data can be exported incase of a perma lock situation
     wait(1, Wait.ABORT_WHEN_FALSE)
-    eventPlayer.editor_lock = true # doesnt matter thats its in pasta's because it wil be fixed on spawning
-    eventPlayer.editor_saveCache[0] = TimeRemaining
+    hostPlayer.editor_lock = true # doesnt matter thats its in pasta's because it wil be fixed on spawning
+    hostPlayer.editor_saveCache[0] = TimeRemaining
     TimeRemaining = null
-    eventPlayer.editor_saveCache[1] = ColorConfig
+    hostPlayer.editor_saveCache[1] = ColorConfig
     ColorConfig = null
 
     CheckpointRings_Editing = null
@@ -47,12 +47,12 @@ rule "Editor | Clear Excess Data to Save Map":
     PortalDest  = null
     PortalEffects = null
     if Name == "name here - 作者":
-        Name = "{}".format(eventPlayer)
+        Name = "{}".format(hostPlayer)
     Cachedcredits = [Name, Code]
     Name = null
     Code = null
     async(AddonCheckMap, AsyncBehavior.NOOP)
-    hudText(eventPlayer,
+    hudText(hostPlayer,
         "­",
         null,
         "   0. 清理无用数据:\n"
@@ -108,25 +108,25 @@ rule "Editor | Clear Excess Data to Save Map":
         " ESC → SHOW LOBBY → SETTINGS → SHARE CODE →\n"
         " UPLOAD TO EXISTING CODE → PASTE THE CODE YOU CREATED IN STEP 4",
        HudPosition.TOP, HO.edit_clearec1, Color.LIME_GREEN,Color.LIME_GREEN,Color.LIME_GREEN, HudReeval.STRING, SpecVisibility.DEFAULT)
-    eventPlayer.editor_saveCache[2]=getLastCreatedText()
+    hostPlayer.editor_saveCache[2]=getLastCreatedText()
 
-    hudHeader(eventPlayer,
+    hudHeader(hostPlayer,
         "    > 按互动键关闭当前窗口 <    "
         checkCN
         "    > Press Interact to close this window <    "
         , HudPosition.TOP, HO.edit_clearec3, Color.LIME_GREEN, HudReeval.STRING)
-    eventPlayer.editor_saveCache[3]=getLastCreatedText()
+    hostPlayer.editor_saveCache[3]=getLastCreatedText()
 
     enableInspector()
     disableInspector()
-    waitUntil(not eventPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
-    waitUntil(eventPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
-    TimeRemaining = eventPlayer.editor_saveCache[0]
-    ColorConfig = eventPlayer.editor_saveCache[1]
-    destroyHudText(eventPlayer.editor_saveCache[2])
-    destroyHudText(eventPlayer.editor_saveCache.last())
-    eventPlayer.editor_saveCache = null
-    eventPlayer.editor_lock = false
+    waitUntil(not hostPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
+    waitUntil(hostPlayer.isHoldingButton(Button.INTERACT), Math.INFINITY)
+    TimeRemaining = hostPlayer.editor_saveCache[0]
+    ColorConfig = hostPlayer.editor_saveCache[1]
+    destroyHudText(hostPlayer.editor_saveCache[2])
+    destroyHudText(hostPlayer.editor_saveCache.last())
+    hostPlayer.editor_saveCache = null
+    hostPlayer.editor_lock = false
 
 rule "Editor | Hud and Effects":
     waitUntil(entityExists(hostPlayer), Math.INFINITY)  # cant be condition because host player can leaves, removing the rule fx
@@ -619,7 +619,7 @@ rule "Editor | Hud and Effects":
 # global functions ==============================================================
 rule "Editor |  Fly/Noclip Toggle":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
+    @Condition eventPlayer.editor_on
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_1)
     @Condition eventPlayer.editor_fly == null
     @Condition EditorMoveItem == false
@@ -653,23 +653,23 @@ rule "Editor |  Fly/Noclip Toggle":
 
 rule "Editor | change mode":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
-    @Condition eventPlayer.isHoldingButton(Button.MELEE)
-    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) != eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.editor_on
+    @Condition hostPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.MELEE)
+    @Condition hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) != hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)
 
-    eventPlayer.editor_lock = true
-    if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
-        eventPlayer.editor_modeSelect += (5 - 1)
+    hostPlayer.editor_lock = true
+    if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+        hostPlayer.editor_modeSelect += (5 - 1)
     else:
-        eventPlayer.editor_modeSelect += 1
-    eventPlayer.editor_modeSelect %= 5
+        hostPlayer.editor_modeSelect += 1
+    hostPlayer.editor_modeSelect %= 5
     EditUpdateSelectedIds()
     EditorSelectLast()
     wait()
-    waitUntil(eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) == eventPlayer.isHoldingButton(Button.SECONDARY_FIRE), 0.1)
-    eventPlayer.editor_lock = false
+    waitUntil(hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) == hostPlayer.isHoldingButton(Button.SECONDARY_FIRE), 0.1)
+    hostPlayer.editor_lock = false
 
 def EditUpdateSelectedIds():
     @Name "Editor | update selected id"
@@ -691,58 +691,54 @@ def EditorSelectLast():
 
 rule "Editor | create cp/orb":
     @Event eachPlayer
-    @Condition eventPlayer.editor_on
     @Condition eventPlayer == hostPlayer
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT)
-    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.editor_on
+    @Condition hostPlayer.editor_lock == false
     @Condition EditorMode.current in [0,1,2,4]
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT)
+    @Condition hostPlayer.isHoldingButton(Button.PRIMARY_FIRE)
 
-    eventPlayer.editor_lock = true
+    hostPlayer.editor_lock = true
     if EditorMode.checkpoint:
-        if len(CheckpointPositions) and distance(eventPlayer, CheckpointPositions[hostPlayer.checkpoint_current]) <= cpcircleradius:
-            smallMessage(eventPlayer, "   放置的检查点距离太近" checkCN "   Cannot place checkpoint too close.")
-            goto lbl_a
-
-        if eventPlayer.checkpoint_current >= len(CheckpointPositions) - 1:
-            eventPlayer.checkpoint_current = len(CheckpointPositions) - 1
-
-        if hostPlayer.checkpoint_current == len(CheckpointPositions) - 1:
-            CheckpointPositions.append(eventPlayer.getPosition() )
-            eventPlayer.checkpoint_current++
-            UpdateCache()
+        if len(CheckpointPositions) and distance(hostPlayer, CheckpointPositions[hostPlayer.checkpoint_current]) <= cpcircleradius:
+            smallMessage(hostPlayer, "   放置的检查点距离太近" checkCN "   Cannot place checkpoint too close.")
         else:
-            insert(CheckpointPositions, hostPlayer.checkpoint_current + 1, eventPlayer.getPosition())
-            hostPlayer.checkpoint_current++
+            #$$
+            if hostPlayer.checkpoint_current >= len(CheckpointPositions) - 1:
+                hostPlayer.checkpoint_current = len(CheckpointPositions) - 1
 
-            KillballCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in KillballCheckpoints]
-            BouncePadCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BouncePadCheckpoints]
-            CustomPortalCP = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in CustomPortalCP]
-            BladeEnabledCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BladeEnabledCheckpoints]
-            DashEnabledCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in DashEnabledCheckpoints]
+            if hostPlayer.checkpoint_current == len(CheckpointPositions) - 1:
+                CheckpointPositions.append(hostPlayer.getPosition())
+                hostPlayer.checkpoint_current++ 
+            else:
+                insert(CheckpointPositions, hostPlayer.checkpoint_current + 1, hostPlayer.getPosition())
+                hostPlayer.checkpoint_current++
 
-            BanMulti = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanMulti]
-            BanCreate = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanCreate]
-            BanStand = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanStand]
-            BanDead = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanDead]
-            BanEmote = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanEmote]
-            BanClimb = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanClimb]
-            BanSaveDouble = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanSaveDouble]
-            BanBhop = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanBhop]
-            BanDjump = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanDjump]
+                KillballCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in KillballCheckpoints]
+                BouncePadCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BouncePadCheckpoints]
+                CustomPortalCP = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in CustomPortalCP]
+                BladeEnabledCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BladeEnabledCheckpoints]
+                DashEnabledCheckpoints = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in DashEnabledCheckpoints]
 
-        smallMessage(localPlayer, "   新检查点已创建" checkCN "   New checkpoint created")
-
+                BanMulti = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanMulti]
+                BanCreate = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanCreate]
+                BanStand = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanStand]
+                BanDead = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanDead]
+                BanEmote = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanEmote]
+                BanClimb = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanClimb]
+                BanSaveDouble = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanSaveDouble]
+                BanBhop = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanBhop]
+                BanDjump = [x + (1 if x >= hostPlayer.checkpoint_current else 0) for x in BanDjump]
+            UpdateCache()
+            smallMessage(hostPlayer, "   新检查点已创建" checkCN "   New checkpoint created")
     elif not len(CheckpointPositions):
-        smallMessage(eventPlayer, "   请先放置检查点" checkCN "   You first have to make a checkpoint")
-        goto lbl_a
+        smallMessage(hostPlayer, "   请先放置检查点" checkCN "   Make a checkpoint first")
     elif len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart) >= fxLimit:
-        bigMessage(eventPlayer, "当前地图弹球/传送门数量已达上限" checkCN "Orb/portal limit reached for this map")
-        goto lbl_a
+        bigMessage(hostPlayer, "当前地图弹球/传送门数量已达上限" checkCN "Orb/portal limit reached for this map")
 
     elif EditorMode.killBall:
-        KillBallPositions.append(eventPlayer.getPosition())
-        KillballCheckpoints.append(eventPlayer.checkpoint_current)
+        KillBallPositions.append(hostPlayer.getPosition())
+        KillballCheckpoints.append(hostPlayer.checkpoint_current)
         KillBallRadii.append(5)
         EditUpdateSelectedIds() # to create the fx properly
         EditorSelectLast()
@@ -751,19 +747,19 @@ rule "Editor | create cp/orb":
             Effect.SPHERE, ColorConfig[Customize.killorb],
             KillBallPositions[evalOnce(EditSelected)],
             abs(KillBallRadii[evalOnce(EditSelected)]),
-            EffectReeval.VISIBILITY_POSITION_AND_RADIUS
-        )
+            EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
         KillBallEffects.append(getLastCreatedEntity())
-        bigMessage(true[0], "{1} {0}".format(eventPlayer.checkpoint_current, "新击杀球已创建! \n仅生效于检查点" checkCN "New boundary sphere has been created! \nOnly valid for this checkpoint"))
-        waitUntil(not (eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
+        bigMessage(true[0], "{1} {0}".format(hostPlayer.checkpoint_current, "新击杀球已创建! \n仅生效于检查点" checkCN "New boundary sphere has been created! \nOnly valid for this checkpoint"))
+        waitUntil(not(hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
         #EditUpdateSelectedIds() # to arrow during the placement properly
-        while eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
-            KillBallPositions[EditSelected] = raycast(eventPlayer.getEyePosition(), eventPlayer.getEyePosition()+eventPlayer.getFacingDirection() * 8, null, null, false).getHitPosition()
+        while hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+            KillBallPositions[EditSelected] = raycast(hostPlayer.getEyePosition(), hostPlayer.getEyePosition()+hostPlayer.getFacingDirection() * 8, null, null, false).getHitPosition()
             wait()
+        EditorMoveItem = true #UpdateCache()
 
     elif EditorMode.functionOrb:
-        BouncePositions.append(eventPlayer.getPosition())
-        BouncePadCheckpoints.append(eventPlayer.checkpoint_current)
+        BouncePositions.append(hostPlayer.getPosition())
+        BouncePadCheckpoints.append(hostPlayer.checkpoint_current)
         BounceStrength.append(10)
         BounceToggleUlt.append(false)
         BounceToggleDash.append(false)
@@ -773,102 +769,94 @@ rule "Editor | create cp/orb":
         createEffect(
             [x for x in getAllPlayers().concat(null) if x.checkpoint_current == BouncePadCheckpoints[evalOnce(EditSelected)] and not (evalOnce(EditSelected) in x.cache_collectedLocks)],
             Effect.ORB, ColorConfig[Customize.orb_lock] if BounceToggleLock[evalOnce(EditSelected)] else ColorConfig[Customize.orb_normal],
-            BouncePositions[evalOnce(EditSelected)], 1, EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR
-        )
+            BouncePositions[evalOnce(EditSelected)], 1, EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR)
         BounceEffects.append(getLastCreatedEntity())
-        bigMessage(true[0], "{1} {0}".format(eventPlayer.checkpoint_current, "新弹球已创建! \n仅生效于检查点" checkCN "New Bounce Orb has been created! \nOnly valid for this checkpoint"))
-        waitUntil(not (eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
-        while eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
-            BouncePositions[EditSelected] = raycast(eventPlayer.getEyePosition(), eventPlayer.getEyePosition()+eventPlayer.getFacingDirection() * 7, null, null, false).getHitPosition()
+        bigMessage(true[0], "{1} {0}".format(hostPlayer.checkpoint_current, "新弹球已创建! \n仅生效于检查点" checkCN "New Bounce Orb has been created! \nOnly valid for this checkpoint"))
+        waitUntil(not(hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
+        while hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+            BouncePositions[EditSelected] = raycast(hostPlayer.getEyePosition(), hostPlayer.getEyePosition() + hostPlayer.getFacingDirection() * 7, null, null, false).getHitPosition()
             wait()
+        EditorMoveItem = true #UpdateCache()
 
     elif EditorMode.portal:
-        CustomPortalStart.append(eventPlayer.getPosition())
-        CustomPortalEndpoint.append(eventPlayer.getPosition() + 10 * Vector.UP)
-        CustomPortalCP.append(eventPlayer.checkpoint_current)
+        CustomPortalStart.append(hostPlayer.getPosition())
+        CustomPortalEndpoint.append(hostPlayer.getPosition() + 10 * Vector.UP)
+        CustomPortalCP.append(hostPlayer.checkpoint_current)
         EditUpdateSelectedIds()
         EditorSelectLast()
-        createEffect(
-            [i for i in getAllPlayers() if CustomPortalCP[evalOnce(EditSelected)] == i.checkpoint_current or CustomPortalCP[evalOnce(EditSelected)] < 0 ],
-            Effect.GOOD_AURA, ColorConfig[Customize.portal], CustomPortalStart[evalOnce(EditSelected)], 0.6,  EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR
-        )
+        createEffect([i for i in getAllPlayers() if CustomPortalCP[evalOnce(EditSelected)] == i.checkpoint_current or CustomPortalCP[evalOnce(EditSelected)] < 0],
+            Effect.GOOD_AURA, ColorConfig[Customize.portal], CustomPortalStart[evalOnce(EditSelected)], 0.6,  EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR)
         PortalEffects.append(getLastCreatedEntity())
         EditSelected = len(CustomPortalStart) - 1
-        waitUntil(not (eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
+        waitUntil(not(hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE)), true)
         #EditUpdateSelectedIds()
-        while eventPlayer.isHoldingButton(Button.INTERACT) and eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
-            CustomPortalStart[EditSelected] = raycast(eventPlayer.getEyePosition(), eventPlayer.getEyePosition()+eventPlayer.getFacingDirection() * 6, null, null, false).getHitPosition()
+        while hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+            CustomPortalStart[EditSelected] = raycast(hostPlayer.getEyePosition(), hostPlayer.getEyePosition() + hostPlayer.getFacingDirection() * 6, null, null, false).getHitPosition()
             wait()
 
         bigMessage(true[0], "新传送门已创建!\n生效于当前检查点" checkCN "Portal created \nOnly valid for this checkpoint")
         EditorMoveItem = true
-        return
-    else:
-        goto lbl_a
 
-    UpdateCache()
-
-    lbl_a:
-    eventPlayer.editor_lock = false
+    hostPlayer.editor_lock = false
     wait(0.64)
 
 rule "Editor | delete cp/orb/portal":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT)
-    @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
+    @Condition hostPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT)
+    @Condition hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)
     #@Condition EditorMoveItem == false
     #@Condition len(EditSelectIdArray) > 0
-    @Condition eventPlayer.editor_lock == false
 
-    eventPlayer.editor_lock = true
+    hostPlayer.editor_lock = true
     if EditorMode.checkpoint and len(CheckpointPositions):
         # Resync Kill Orbs ==================
-        eventPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in KillballCheckpoints] if  e >= 0]
-        # eventPlayer.editor_temp = [i for e, i in KillballCheckpoints if e == hostPlayer.checkpoint_current]
-        for TempIterator1 in range(len(eventPlayer.editor_temp)):
-            destroyEffect(KillBallEffects[eventPlayer.editor_temp[TempIterator1]])
-            del KillBallEffects[eventPlayer.editor_temp[TempIterator1]]
+        hostPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in KillballCheckpoints] if  e >= 0]
+        # hostPlayer.editor_temp = [i for e, i in KillballCheckpoints if e == hostPlayer.checkpoint_current]
+        for TempIterator1 in range(len(hostPlayer.editor_temp)):
+            destroyEffect(KillBallEffects[hostPlayer.editor_temp[TempIterator1]])
+            del KillBallEffects[hostPlayer.editor_temp[TempIterator1]]
             wait()
         # Remove specified checkpoint
         KillballCheckpoints = [x for x in KillballCheckpoints if x != hostPlayer.checkpoint_current]
         # Decrement checkpoints after removed one
         KillballCheckpoints = [x - (1 if x > hostPlayer.checkpoint_current else 0) for x in KillballCheckpoints]
         # Remove Radii at Checkpoint indexes (temp)
-        KillBallRadii = [x for x, i in KillBallRadii if i not in eventPlayer.editor_temp]
-        KillBallPositions = [x for x, i in KillBallPositions if i not in eventPlayer.editor_temp]
+        KillBallRadii = [x for x, i in KillBallRadii if i not in hostPlayer.editor_temp]
+        KillBallPositions = [x for x, i in KillBallPositions if i not in hostPlayer.editor_temp]
         # Resync Bounce Orbs ==============
-        eventPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in BouncePadCheckpoints] if  e >= 0]
-        # eventPlayer.editor_temp = [i for e, i in BouncePadCheckpoints if e == hostPlayer.checkpoint_current]
-        for TempIterator1 in range(len(eventPlayer.editor_temp)):
-            destroyEffect(BounceEffects[eventPlayer.editor_temp[TempIterator1]])
-            del BounceEffects[eventPlayer.editor_temp[TempIterator1]]
+        hostPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in BouncePadCheckpoints] if  e >= 0]
+        # hostPlayer.editor_temp = [i for e, i in BouncePadCheckpoints if e == hostPlayer.checkpoint_current]
+        for TempIterator1 in range(len(hostPlayer.editor_temp)):
+            destroyEffect(BounceEffects[hostPlayer.editor_temp[TempIterator1]])
+            del BounceEffects[hostPlayer.editor_temp[TempIterator1]]
             wait()
 
         BouncePadCheckpoints = [x for x in BouncePadCheckpoints if x != hostPlayer.checkpoint_current]
         # Decrement checkpoints after removed one
         BouncePadCheckpoints = [x - (1 if x > hostPlayer.checkpoint_current else 0) for x in BouncePadCheckpoints]
-        BouncePositions = [x for x, i in BouncePositions if i not in eventPlayer.editor_temp]
-        BounceStrength = [x for x, i in BounceStrength if i not in eventPlayer.editor_temp]
-        BounceToggleUlt = [x for x, i in BounceToggleUlt if i not in eventPlayer.editor_temp]
-        BounceToggleDash = [x for x, i in BounceToggleDash if i not in eventPlayer.editor_temp]
-        BounceToggleLock = [x for x, i in BounceToggleLock if i not in eventPlayer.editor_temp]
+        BouncePositions = [x for x, i in BouncePositions if i not in hostPlayer.editor_temp]
+        BounceStrength = [x for x, i in BounceStrength if i not in hostPlayer.editor_temp]
+        BounceToggleUlt = [x for x, i in BounceToggleUlt if i not in hostPlayer.editor_temp]
+        BounceToggleDash = [x for x, i in BounceToggleDash if i not in hostPlayer.editor_temp]
+        BounceToggleLock = [x for x, i in BounceToggleLock if i not in hostPlayer.editor_temp]
 
         # Resync custom portals ==================
-        eventPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in CustomPortalCP] if  e >=0]
-        for TempIterator1 in range(len(eventPlayer.editor_temp)):
-            destroyEffect(PortalEffects[eventPlayer.editor_temp[TempIterator1]])
-            del PortalEffects[eventPlayer.editor_temp[TempIterator1]]
+        hostPlayer.editor_temp = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in CustomPortalCP] if  e >=0]
+        for TempIterator1 in range(len(hostPlayer.editor_temp)):
+            destroyEffect(PortalEffects[hostPlayer.editor_temp[TempIterator1]])
+            del PortalEffects[hostPlayer.editor_temp[TempIterator1]]
             wait()
         # Remove specified checkpoint
         CustomPortalCP = [x for x in CustomPortalCP if x != hostPlayer.checkpoint_current]
         # Decrement checkpoints after removed one
         CustomPortalCP = [x - (1 if x > hostPlayer.checkpoint_current else 0) for x in CustomPortalCP]
         # Remove Radii at Checkpoint indexes (temp)
-        CustomPortalStart = [x for x, i in CustomPortalStart if i not in eventPlayer.editor_temp]
-        CustomPortalEndpoint = [x for x, i in CustomPortalEndpoint if i not in eventPlayer.editor_temp]
-        eventPlayer.editor_temp = null
+        CustomPortalStart = [x for x, i in CustomPortalStart if i not in hostPlayer.editor_temp]
+        CustomPortalEndpoint = [x for x, i in CustomPortalEndpoint if i not in hostPlayer.editor_temp]
+        hostPlayer.editor_temp = null
 
         # ult/dash/ban remove and lower the cp number of rest
         removeCPandLower(BladeEnabledCheckpoints)
@@ -895,7 +883,7 @@ rule "Editor | delete cp/orb/portal":
         RebuildKillOrbs()
         RebuildBounceOrbs()
         RebuildPortals()
-        smallMessage(localPlayer, "   检查点已删除" checkCN "   Checkpoint has been deleted")
+        smallMessage(hostPlayer, "   检查点已删除" checkCN "   Checkpoint has been deleted")
     elif EditorMode.killBall and len(EditSelectIdArray):
         del KillBallPositions[EditSelected]
         del KillBallRadii[EditSelected]
@@ -922,102 +910,101 @@ rule "Editor | delete cp/orb/portal":
         del PortalEffects[EditSelected]
         RebuildPortals()
     else:
-        eventPlayer.editor_lock = false
+        hostPlayer.editor_lock = false
         wait()
         return
 
     UpdateCache()
     EditorSelectLast()
-    eventPlayer.editor_lock = false
+    hostPlayer.editor_lock = false
     wait(0.16 + (getNumberOfEntityIds()*0.007))
 
 # orb functions ==============================================================
 
 rule "Editor | toggle orb functions":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.functionOrb
-    @Condition eventPlayer.isHoldingButton(Button.ULTIMATE)
-    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) or eventPlayer.isHoldingButton(Button.ABILITY_2)
+    @Condition hostPlayer.editor_lock == false
     @Condition len(EditSelectIdArray) > 0
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.ULTIMATE)
+    @Condition hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE) or hostPlayer.isHoldingButton(Button.ABILITY_2)
 
-    eventPlayer.editor_lock = true
-    if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+    hostPlayer.editor_lock = true
+    if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
         BounceToggleUlt[EditSelected] = not BounceToggleUlt[EditSelected]
-    elif eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+    elif hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
         BounceToggleDash[EditSelected] = not BounceToggleDash[EditSelected]
     else:
         BounceToggleLock[EditSelected] = not BounceToggleLock[EditSelected]
         BounceStrength[EditSelected] = 0 if BounceToggleLock[EditSelected] else 10
 
     UpdateCache()
-    eventPlayer.editor_lock = false
+    hostPlayer.editor_lock = false
     wait()
 
 rule "Editor | orb radi/strength":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1,2]
+    @Condition hostPlayer.editor_lock == false
     @Condition len(EditSelectIdArray) > 0
-    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
-    @Condition eventPlayer.isHoldingButton(Button.JUMP) != eventPlayer.isHoldingButton(Button.CROUCH)
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT) == false
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.ABILITY_2)
+    @Condition hostPlayer.isHoldingButton(Button.JUMP) != hostPlayer.isHoldingButton(Button.CROUCH)
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT) == false
 
-    eventPlayer.editor_lock = true
-    while eventPlayer.isHoldingButton(Button.ABILITY_2) and (eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isHoldingButton(Button.CROUCH)) :
-        if EditorMode.functionOrb and len(eventPlayer.editor_bounceIndex):
-            BounceStrength[EditSelected] += 0.1 if eventPlayer.isHoldingButton(Button.JUMP) else -0.1
-        elif EditorMode.killBall and len(eventPlayer.editor_killIndex):
-            KillBallRadii[EditSelected] +=  0.1 if eventPlayer.isHoldingButton(Button.JUMP) else -0.1
+    hostPlayer.editor_lock = true
+    while hostPlayer.isHoldingButton(Button.ABILITY_2) and (hostPlayer.isHoldingButton(Button.JUMP) or hostPlayer.isHoldingButton(Button.CROUCH)) :
+        if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex):
+            BounceStrength[EditSelected] += 0.1 if hostPlayer.isHoldingButton(Button.JUMP) else -0.1
+        elif EditorMode.killBall and len(hostPlayer.editor_killIndex):
+            KillBallRadii[EditSelected] +=  0.1 if hostPlayer.isHoldingButton(Button.JUMP) else -0.1
         wait(0.1)
     UpdateCache()
-    eventPlayer.editor_lock = false
+    hostPlayer.editor_lock = false
 
 rule "Editor | select orb/portal":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1,2,4]
+    @Condition hostPlayer.editor_lock == false
     @Condition len(EditSelectIdArray) > 0
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT)
-    @Condition eventPlayer.isHoldingButton(Button.CROUCH) or eventPlayer.isHoldingButton(Button.JUMP)
-    #@Condition EditorMoveItem == false
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT)
+    @Condition hostPlayer.isHoldingButton(Button.CROUCH) or hostPlayer.isHoldingButton(Button.JUMP)
 
-    eventPlayer.editor_lock = true
-    if eventPlayer.isHoldingButton(Button.CROUCH):
+    hostPlayer.editor_lock = true
+    if hostPlayer.isHoldingButton(Button.CROUCH):
         EditSelected = EditSelectIdArray.last() if EditSelectIdArray.index(EditSelected) == 0 else EditSelectIdArray[EditSelectIdArray.index(EditSelected) - 1]
     else:
         EditSelected = EditSelectIdArray[0] if EditSelectIdArray.index(EditSelected) == len(EditSelectIdArray) - 1 else EditSelectIdArray[EditSelectIdArray.index(EditSelected) + 1]
-
     wait()
-    eventPlayer.editor_lock = false
-    waitUntil(not eventPlayer.isHoldingButton(Button.INTERACT) or not (eventPlayer.isHoldingButton(Button.CROUCH) or eventPlayer.isHoldingButton(Button.JUMP)), 0.24)
+    hostPlayer.editor_lock = false
+    waitUntil(not hostPlayer.isHoldingButton(Button.INTERACT) or not (hostPlayer.isHoldingButton(Button.CROUCH) or hostPlayer.isHoldingButton(Button.JUMP)), 0.24)
 
 # checkpoint functions ==============================================================
 
 rule "Editor | cp size hitbox display":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current == 0
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT)
-    @Condition eventPlayer.isHoldingButton(Button.ABILITY_1)
-    eventPlayer.editor_hitboxToggle = not eventPlayer.editor_hitboxToggle
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT)
+    @Condition hostPlayer.isHoldingButton(Button.ABILITY_1)
+    hostPlayer.editor_hitboxToggle = not hostPlayer.editor_hitboxToggle
     wait()
 
 rule "Editor | cp add/remove teleport":
     @Condition hostPlayer.editor_on
+    @Condition EditorMode.current == 0
+    @Condition hostPlayer.editor_lock == false
+    @Condition len(CheckpointPositions) > 1
     @Condition hostPlayer.isHoldingButton(Button.INTERACT)
     @Condition hostPlayer.isHoldingButton(Button.RELOAD)
     @Condition hostPlayer.isHoldingButton(Button.MELEE) == false
-    @Condition len(CheckpointPositions) > 1
-    @Condition EditorMode.current == 0
-    @Condition hostPlayer.editor_lock == false
+
     waitUntil(hostPlayer.isHoldingButton(Button.MELEE) or not (hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.RELOAD)), true) # prevent overlap with save map
     if hostPlayer.isHoldingButton(Button.MELEE) or hostPlayer.isHoldingButton(Button.INTERACT) and hostPlayer.isHoldingButton(Button.RELOAD):
       return
@@ -1043,49 +1030,50 @@ rule "Editor | cp add/remove teleport":
 
 rule "Editor | moving checkpoint":
     @Event eachPlayer
-    @Condition eventPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current == 0
-    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
-    @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) == false
+    @Condition hostPlayer.editor_lock == false
     @Condition len(CheckpointPositions) > 0
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.ABILITY_2)
+    @Condition hostPlayer.isHoldingButton(Button.SECONDARY_FIRE) == false
+    
     wait(0.3, Wait.ABORT_WHEN_FALSE)
-    if eventPlayer.addon_toggle3rdPov:
-        eventPlayer.addon_toggle3rdPov = false
-    eventPlayer.editor_lock = true
-    eventPlayer.editor_undo = CheckpointPositions[eventPlayer.checkpoint_current]
-    eventPlayer.startCamera(eventPlayer.getEyePosition() + 0.5 * Vector.UP - 2.5 * eventPlayer.getFacingDirection(), eventPlayer.getEyePosition(), 15)
-    while eventPlayer.isHoldingButton(Button.ABILITY_2) and eventPlayer.isAlive() and not eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
-            eventPlayer.setMoveSpeed(100)
+    if hostPlayer.addon_toggle3rdPov:
+        hostPlayer.addon_toggle3rdPov = false
+    hostPlayer.editor_lock = true
+    hostPlayer.editor_undo = CheckpointPositions[hostPlayer.checkpoint_current]
+    hostPlayer.startCamera(hostPlayer.getEyePosition() + 0.5 * Vector.UP - 2.5 * hostPlayer.getFacingDirection(), hostPlayer.getEyePosition(), 15)
+    while hostPlayer.isHoldingButton(Button.ABILITY_2) and hostPlayer.isAlive() and not hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+            hostPlayer.setMoveSpeed(100)
         else:
-            eventPlayer.setMoveSpeed(3)
-        if len(CheckpointPositions[eventPlayer.checkpoint_current]):
-            CheckpointPositions[eventPlayer.checkpoint_current] = [eventPlayer.getPosition(), CheckpointPositions[eventPlayer.checkpoint_current][1] ]
+            hostPlayer.setMoveSpeed(3)
+        if len(CheckpointPositions[hostPlayer.checkpoint_current]):
+            CheckpointPositions[hostPlayer.checkpoint_current] = [hostPlayer.getPosition(), CheckpointPositions[hostPlayer.checkpoint_current][1] ]
         else:
-            CheckpointPositions[eventPlayer.checkpoint_current] = eventPlayer.getPosition()
+            CheckpointPositions[hostPlayer.checkpoint_current] = hostPlayer.getPosition()
         wait()
 
-    eventPlayer.stopCamera()
-    eventPlayer.setMoveSpeed(100)
-    if eventPlayer.isHoldingButton(Button.ABILITY_2):
-        CheckpointPositions[eventPlayer.checkpoint_current] = eventPlayer.editor_undo
-        waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_2), Math.INFINITY)
+    hostPlayer.stopCamera()
+    hostPlayer.setMoveSpeed(100)
+    if hostPlayer.isHoldingButton(Button.ABILITY_2):
+        CheckpointPositions[hostPlayer.checkpoint_current] = hostPlayer.editor_undo
+        waitUntil(not hostPlayer.isHoldingButton(Button.ABILITY_2), Math.INFINITY)
 
-    eventPlayer.editor_lock = false
+    hostPlayer.editor_lock = false
 
 rule "Editor | add ult/dash":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current == 0
+    @Condition hostPlayer.editor_lock == false
     @Condition len(CheckpointPositions) > 0
-    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) != eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
-    @Condition eventPlayer.isHoldingButton(Button.ULTIMATE)
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) != hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)
+    @Condition hostPlayer.isHoldingButton(Button.ULTIMATE)
 
-    if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+    if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
         toggleCpInArray(BladeEnabledCheckpoints)
     else:
         toggleCpInArray(DashEnabledCheckpoints)
@@ -1093,141 +1081,138 @@ rule "Editor | add ult/dash":
 
 rule "Editor | toggle bans":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.skillBan
+    @Condition hostPlayer.editor_lock == false
     @Condition len(CheckpointPositions) > 0
-    @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) or eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isHoldingButton(Button.CROUCH)
-    @Condition eventPlayer.isHoldingButton(Button.INTERACT) or eventPlayer.isHoldingButton(Button.ABILITY_2)
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE) or hostPlayer.isHoldingButton(Button.JUMP) or hostPlayer.isHoldingButton(Button.CROUCH)
+    @Condition hostPlayer.isHoldingButton(Button.INTERACT) or hostPlayer.isHoldingButton(Button.ABILITY_2)
 
-    eventPlayer.editor_lock = true
-    if eventPlayer.isHoldingButton(Button.INTERACT):
-        if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+    hostPlayer.editor_lock = true
+    if hostPlayer.isHoldingButton(Button.INTERACT):
+        if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
             toggleCpInArray(BanMulti)
-        elif eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        elif hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
             toggleCpInArray(BanCreate)
-        elif eventPlayer.isHoldingButton(Button.CROUCH):
+        elif hostPlayer.isHoldingButton(Button.CROUCH):
             toggleCpInArray(BanClimb)
         else:
             toggleCpInArray(BanSaveDouble)
 
     else:
-        if eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
+        if hostPlayer.isHoldingButton(Button.PRIMARY_FIRE):
             toggleCpInArray(BanDead)
             #toggleCpInArray(BanSaveDouble)
-        elif eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        elif hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
             toggleCpInArray(BanEmote)
-        elif eventPlayer.isHoldingButton(Button.CROUCH):
+        elif hostPlayer.isHoldingButton(Button.CROUCH):
             toggleCpInArray(BanStand)
         else:
             toggleCpInArray(BanBhop)
-
     # BanStand
-
     wait(0.3)
     UpdateCache()
-    eventPlayer.editor_lock = false
-
+    hostPlayer.editor_lock = false
 
 rule "Editor | portal cp change":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.portal
-    @Condition eventPlayer.isHoldingButton(Button.JUMP)
-    @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
+    @Condition hostPlayer.editor_lock == false
     @Condition len(EditSelectIdArray) > 0
-    #@Condition EditorMoveItem == false
-    @Condition eventPlayer.editor_lock == false
+    @Condition hostPlayer.isHoldingButton(Button.JUMP)
+    @Condition hostPlayer.isHoldingButton(Button.ABILITY_2)
 
-    CustomPortalCP[EditSelected] = eventPlayer.checkpoint_current if CustomPortalCP[EditSelected] < 0 else -1
+    CustomPortalCP[EditSelected] = hostPlayer.checkpoint_current if CustomPortalCP[EditSelected] < 0 else -1
     wait(0.3)
 
 rule "Editor | move object":
     @Event eachPlayer
-    @Condition hostPlayer.editor_on
     @Condition eventPlayer == hostPlayer
+    @Condition hostPlayer.editor_on
     @Condition EditorMode.current in [1, 2, 4]
-    @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) == false
-    @Condition EditorMoveItem or (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) and eventPlayer.isHoldingButton(Button.ABILITY_2) and eventPlayer.editor_lock == false)
+    @Condition hostPlayer.editor_lock == false
     @Condition len(EditSelectIdArray) > 0
+    @Condition hostPlayer.isHoldingButton(Button.SECONDARY_FIRE) == false
+    @Condition EditorMoveItem or (hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) and hostPlayer.isHoldingButton(Button.ABILITY_2))
 
-    eventPlayer.editor_lock = true
+    hostPlayer.editor_lock = true
     EditorMoveItem = true
-    if eventPlayer.addon_toggle3rdPov:
-        eventPlayer.addon_toggle3rdPov = false
-    #eventPlayer.editor_fly = null
+    if hostPlayer.addon_toggle3rdPov:
+        hostPlayer.addon_toggle3rdPov = false
+    #hostPlayer.editor_fly = null
 
-    waitUntil(not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.ABILITY_2)), true)
-    #eventPlayer.disallowButton(Button.ULTIMATE)
-    #eventPlayer.disallowButton(Button.JUMP)
-    eventPlayer.setStatusEffect(null, Status.HACKED, Math.INFINITY)
-    eventPlayer.setMoveSpeed(false)
-    #eventPlayer.startForcingPosition(eventPlayer.getPosition(), false)
+    waitUntil(not(hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.ABILITY_2)), Math.INFINITY)
+
+    #hostPlayer.disallowButton(Button.ULTIMATE)
+    #hostPlayer.disallowButton(Button.JUMP)
+    hostPlayer.setStatusEffect(null, Status.HACKED, Math.INFINITY)
+    hostPlayer.setMoveSpeed(false)
+    #hostPlayer.startForcingPosition(hostPlayer.getPosition(), false)
     
     if EditorMode.killBall:
-        eventPlayer.editor_undo = KillBallPositions[EditSelected]
-        eventPlayer.startCamera(KillBallPositions[EditSelected] + eventPlayer.getFacingDirection() * (abs(KillBallRadii[EditSelected]) * -1.5),
+        hostPlayer.editor_undo = KillBallPositions[EditSelected]
+        hostPlayer.startCamera(KillBallPositions[EditSelected] + hostPlayer.getFacingDirection() * (abs(KillBallRadii[EditSelected]) * -1.5),
             KillBallPositions[EditSelected], 30)
-        while not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
+        while not (hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
             KillBallPositions[EditSelected] += flyMovementDelta
             wait()
-
     elif EditorMode.functionOrb:
-        eventPlayer.editor_undo = BouncePositions[EditSelected]
-        eventPlayer.startCamera(BouncePositions[EditSelected] + eventPlayer.getFacingDirection() * -4,
+        hostPlayer.editor_undo = BouncePositions[EditSelected]
+        hostPlayer.startCamera(BouncePositions[EditSelected] + hostPlayer.getFacingDirection() * -4,
             BouncePositions[EditSelected], 30)
-        while not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
+        while not (hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
             BouncePositions[EditSelected] += flyMovementDelta
             wait()
-
     elif EditorMode.portal:
-        eventPlayer.editor_undo = [CustomPortalStart[EditSelected], CustomPortalEndpoint[EditSelected]]
+        hostPlayer.editor_undo = [CustomPortalStart[EditSelected], CustomPortalEndpoint[EditSelected]]
         # move start position
-        eventPlayer.startCamera(CustomPortalStart[EditSelected] + eventPlayer.getFacingDirection() * -4,
+        hostPlayer.startCamera(CustomPortalStart[EditSelected] + hostPlayer.getFacingDirection() * -4,
             CustomPortalStart[EditSelected], 30)
-        while not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
+        while not (hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
             CustomPortalStart[EditSelected] += flyMovementDelta
             wait()
 
         # move destination
-        eventPlayer.startCamera(CustomPortalEndpoint[EditSelected] + eventPlayer.getFacingDirection() * -4,
+        hostPlayer.startCamera(CustomPortalEndpoint[EditSelected] + hostPlayer.getFacingDirection() * -4,
             CustomPortalEndpoint[EditSelected], 30)
-        waitUntil(not eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE), true)
-        while not (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
+        waitUntil(not hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE), true)
+        while not (hostPlayer.isHoldingButton(Button.PRIMARY_FIRE) or hostPlayer.isHoldingButton(Button.SECONDARY_FIRE)):
             CustomPortalEndpoint[EditSelected] += flyMovementDelta
             wait()
-
-  /*if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        KillBallPositions[EditSelected] = eventPlayer.editor_undo[0]
-    if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        BouncePositions[EditSelected] = eventPlayer.editor_undo[1]
-    if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        CustomPortalStart[EditSelected] = eventPlayer.editor_undo[2]
-        if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
-        CustomPortalEndpoint[EditSelected] = eventPlayer.editor_undo[3]*/
-    if eventPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+/*  
+    if hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        KillBallPositions[EditSelected] = hostPlayer.editor_undo[0]
+    if hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        BouncePositions[EditSelected] = hostPlayer.editor_undo[1]
+    if hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        CustomPortalStart[EditSelected] = hostPlayer.editor_undo[2]
+    if hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
+        CustomPortalEndpoint[EditSelected] = hostPlayer.editor_undo[3]
+*/
+    if hostPlayer.isHoldingButton(Button.SECONDARY_FIRE):
         goto loc + 2 * EditorMode.current
     else:
     else:
-        KillBallPositions[EditSelected] = eventPlayer.editor_undo
+        KillBallPositions[EditSelected] = hostPlayer.editor_undo
     else:
-        BouncePositions[EditSelected] = eventPlayer.editor_undo
+        BouncePositions[EditSelected] = hostPlayer.editor_undo
     else:
     else:
     else:
-        CustomPortalStart[EditSelected] = eventPlayer.editor_undo[0]
-        CustomPortalEndpoint[EditSelected] = eventPlayer.editor_undo.last()
+        CustomPortalStart[EditSelected] = hostPlayer.editor_undo[0]
+        CustomPortalEndpoint[EditSelected] = hostPlayer.editor_undo.last()
     
-    eventPlayer.editor_undo = null
-    #eventPlayer.allowButton(Button.ULTIMATE)
-    #eventPlayer.allowButton(Button.JUMP)
-    eventPlayer.clearStatusEffect(Status.HACKED)
-    eventPlayer.stopCamera()
-    eventPlayer.setMoveSpeed(100)
-    #eventPlayer.stopForcingPosition()
+    hostPlayer.editor_undo = null
+    #hostPlayer.allowButton(Button.ULTIMATE)
+    #hostPlayer.allowButton(Button.JUMP)
+    hostPlayer.clearStatusEffect(Status.HACKED)
+    hostPlayer.stopCamera()
+    hostPlayer.setMoveSpeed(100)
+    #hostPlayer.stopForcingPosition()
     EditorMoveItem = null
     UpdateCache()
-    waitUntil(not eventPlayer.isHoldingButton(Button.PRIMARY_FIRE), true)
-    eventPlayer.editor_lock = false
+    waitUntil(not hostPlayer.isHoldingButton(Button.PRIMARY_FIRE), true)
+    hostPlayer.editor_lock = false

--- a/editor.opy
+++ b/editor.opy
@@ -29,8 +29,8 @@ rule "Editor | Clear Excess Data to Save Map":
     #SavePauseEnabled = null
     SaveElapsed = null
     CompMode = null
-    LeaderBoardFull = null
-    LeaderBoardHuds = null
+    #LeaderBoardFull = null
+    #LeaderBoardHuds = null
     PortalOn = null
     TitleData = null
     CpHudText = null

--- a/editor.opy
+++ b/editor.opy
@@ -637,8 +637,14 @@ rule "Editor |  Fly/Noclip Toggle":
     waitUntil(not eventPlayer.isHoldingButton(Button.ABILITY_1), true)
 
     while eventPlayer.isAlive() and eventPlayer.editor_fly and not eventPlayer.isHoldingButton(Button.ABILITY_1):
-        if not (eventPlayer == hostPlayer and eventPlayer.editor_lock):
+        if eventPlayer != hostPlayer or not eventPlayer.editor_lock:
             eventPlayer.editor_fly += flyMovementDelta
+        elif EditorMode.checkpoint:
+            #$$ Due to moving checkpoint holding Ability 2
+            eventPlayer.editor_fly += ((0.00288 + 0.09312 * eventPlayer.isHoldingButton(Button.PRIMARY_FIRE)) * \
+                (eventPlayer.getFacingDirection() * eventPlayer.getThrottle().z + \
+                worldVector(eventPlayer.getThrottle() * Vector.LEFT, eventPlayer, Transform.ROTATION) + \
+                Vector.UP * (eventPlayer.isHoldingButton(Button.JUMP) - eventPlayer.isHoldingButton(Button.CROUCH))))
         wait()
     
     eventPlayer.allowButton(Button.ULTIMATE)

--- a/editor.opy
+++ b/editor.opy
@@ -873,11 +873,7 @@ rule "Editor | delete cp/orb/portal":
         # Remove specified checkpoint =====================
         del CheckpointPositions[hostPlayer.checkpoint_current]
         del CheckpointRings_Editing[hostPlayer.checkpoint_current]
-
-        if hostPlayer.checkpoint_current < 1:
-            hostPlayer.checkpoint_current = 0
-        else:
-            hostPlayer.checkpoint_current -= 1
+        hostPlayer.checkpoint_current = max(hostPlayer.checkpoint_current - 1, 0)
 
         RebuildKillOrbs()
         RebuildBounceOrbs()
@@ -916,7 +912,7 @@ rule "Editor | delete cp/orb/portal":
     UpdateCache()
     EditorSelectLast()
     hostPlayer.editor_lock = false
-    wait(0.16 + (getNumberOfEntityIds()*0.007))
+    wait(0.16 + (getNumberOfEntityIds() * 0.007))
 
 # orb functions ==============================================================
 
@@ -937,7 +933,7 @@ rule "Editor | toggle orb functions":
         BounceToggleDash[EditSelected] = not BounceToggleDash[EditSelected]
     else:
         BounceToggleLock[EditSelected] = not BounceToggleLock[EditSelected]
-        BounceStrength[EditSelected] = 0 if BounceToggleLock[EditSelected] else 10
+        BounceStrength[EditSelected] = 10 * BounceToggleLock[EditSelected]
 
     UpdateCache()
     hostPlayer.editor_lock = false
@@ -959,7 +955,7 @@ rule "Editor | orb radi/strength":
         if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex):
             BounceStrength[EditSelected] += 0.1 if hostPlayer.isHoldingButton(Button.JUMP) else -0.1
         elif EditorMode.killBall and len(hostPlayer.editor_killIndex):
-            KillBallRadii[EditSelected] +=  0.1 if hostPlayer.isHoldingButton(Button.JUMP) else -0.1
+            KillBallRadii[EditSelected] += 0.1 if hostPlayer.isHoldingButton(Button.JUMP) else -0.1
         wait(0.1)
     UpdateCache()
     hostPlayer.editor_lock = false
@@ -976,7 +972,7 @@ rule "Editor | select orb/portal":
 
     hostPlayer.editor_lock = true
     if hostPlayer.isHoldingButton(Button.CROUCH):
-        EditSelected = EditSelectIdArray.last() if EditSelectIdArray.index(EditSelected) == 0 else EditSelectIdArray[EditSelectIdArray.index(EditSelected) - 1]
+        EditSelected = EditSelectIdArray.last() if not EditSelectIdArray.index(EditSelected) else EditSelectIdArray[EditSelectIdArray.index(EditSelected) - 1]
     else:
         EditSelected = EditSelectIdArray[0] if EditSelectIdArray.index(EditSelected) == len(EditSelectIdArray) - 1 else EditSelectIdArray[EditSelectIdArray.index(EditSelected) + 1]
     wait()
@@ -1020,8 +1016,7 @@ rule "Editor | cp add/remove teleport":
     else: # add
         CheckpointPositions[hostPlayer.checkpoint_current] = [
             CheckpointPositions[hostPlayer.checkpoint_current][0] if len(CheckpointPositions[hostPlayer.checkpoint_current]) else CheckpointPositions[hostPlayer.checkpoint_current],
-            hostPlayer.getPosition()
-        ]
+            hostPlayer.getPosition()]
         smallMessage(hostPlayer, "{1} {0}".format(hostPlayer.checkpoint_current,"   传送点已添加到当前关卡" checkCN "   Teleport has been added for level"))
 
     hostPlayer.editor_lock = false

--- a/editor.opy
+++ b/editor.opy
@@ -128,492 +128,482 @@ rule "Editor | Clear Excess Data to Save Map":
     hostPlayer.editor_lock = false
 
 rule "Editor | Hud and Effects":
-    waitUntil(entityExists(hostPlayer), Math.INFINITY)  # cant be condition because host player can leaves, removing the rule fx
-    wait(1)
-    if not hostPlayer.editor_on:
-        # clear variables if not in editor mode
-        HudStoreEdit = null
-        return
-    wait(1)
-    #hostPlayer.editor_lock = true
-    while len(HudStoreEdit): # remove unnesesary huds
-        destroyHudText(HudStoreEdit[0])
-        destroyInWorldText(HudStoreEdit[0])
-        del HudStoreEdit[0]
-    wait()
+    wait(LoadOrder.hudsEditor)
+    waitUntil(entityExists(getAllPlayers()), Math.INFINITY)  # cant be condition because host player can leaves, removing the rule fx
+    if getAllPlayers().editor_on:
+        #hostPlayer.editor_lock = true
+        while len(HudStoreEdit): # remove unnesesary huds
+            destroyHudText(HudStoreEdit[0])
+            destroyInWorldText(HudStoreEdit[0])
+            del HudStoreEdit[0]
+        wait()
+        if CompMode: # infinite time and attempts
+            CompAtmpNum = null
+            CompTime = Math.INFINITY
+            getAllPlayers().comp_countAttempts = null
+            getAllPlayers().comp_done = false
+        #CustomPortalStart = CustomPortalStart if len(CustomPortalStart) else []
+        #CustomPortalEndpoint = CustomPortalEndpoint if len(CustomPortalEndpoint) else []
+        #CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else []
+        # huds ==========================================================================================================================================================================
 
-    if CompMode: # infinite time and attempts
-        CompAtmpNum = null
-        CompTime = Math.INFINITY
-        getAllPlayers().comp_countAttempts = null
-        getAllPlayers().comp_done = false
+        # restart without leaderboard (old one deleted)
+        hudSubtext(localPlayer.toggle_guide,  # restart without leadwerboard
+            "{0}+{1}+{2} | 重新开始".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT))
+            checkCN
+            "{0}+{1}+{2} | Restart".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT)),
+            HudPosition.RIGHT, HO.com_restart_n_board, ColorConfig[Customize.command_normal], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    #CustomPortalStart = CustomPortalStart if len(CustomPortalStart) else []
-    #CustomPortalEndpoint = CustomPortalEndpoint if len(CustomPortalEndpoint) else []
-    #CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else []
+        # hud 1
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide else null,
+            ([  "{0} + {1} | 新建检查点\n"
+                "{0} + {2} | 删除选中的检查点".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
 
-    # huds ==========================================================================================================================================================================
+                "{0} + {1} | 新建击杀球\n"
+                "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
 
-    # restart without leaderboard (old one deleted)
-    hudSubtext(localPlayer.toggle_guide,  # restart without leadwerboard
-        "{0}+{1}+{2} | 重新开始".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT))
-        checkCN
-        "{0}+{1}+{2} | Restart".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT)),
-        HudPosition.RIGHT, HO.com_restart_n_board, ColorConfig[Customize.command_normal], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+                "{0} + {1} | 新建弹球\n"
+                "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
 
-    # hud 1
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide else null,
-        ([  "{0} + {1} | 新建检查点\n"
-            "{0} + {2} | 删除选中的检查点".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
+                "{0} + {1} | 蹭留\n"
+                "{0} + {2} | 卡小".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
 
-            "{0} + {1} | 新建击杀球\n"
-            "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | 新建传送门\n"
+                "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+            ][EditorMode.current] if not EditorMoveItem else
+                "方向键 | 移动实体 \n"
+                "{0} | 向上移动 \n"
+                "{1} | 向下移动 \n"
+                "{2} (长按) | 快速移动".format(buttonString(Button.ABILITY_2), buttonString(Button.ULTIMATE),  buttonString(Button.JUMP))
+            ) checkCN
+            ([
+                "{0} + {1} | Create New\n"
+                "{0} + {2} | Delete selected".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
 
-            "{0} + {1} | 新建弹球\n"
-            "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | Create new\n"
+                "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
 
-            "{0} + {1} | 蹭留\n"
-            "{0} + {2} | 卡小".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
+                "{0} + {1} | Create new\n"
+                "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
 
-            "{0} + {1} | 新建传送门\n"
-            "{0} + {1} (长按) | 在准心位置新建".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
-        ][EditorMode.current] if not EditorMoveItem else
-            "方向键 | 移动实体 \n"
-            "{0} | 向上移动 \n"
-            "{1} | 向下移动 \n"
-            "{2} (长按) | 快速移动".format(buttonString(Button.ABILITY_2), buttonString(Button.ULTIMATE),  buttonString(Button.JUMP))
-        ) checkCN
+                "{0} + {1} | multiclimb\n"
+                "{0} + {2} | createbhop".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)
+                ),
+                "{0} + {1} | create new\n"
+                "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+            ][EditorMode.current] if not EditorMoveItem else
+                "walk | move selected\n"
+                "{0} | move up\n"
+                "{1} | move down\n"
+                "{2} (hold) | move faster".format(buttonString(Button.ABILITY_2), buttonString(Button.ULTIMATE), buttonString(Button.JUMP))),
+            HudPosition.RIGHT, HO.edit_instructions_edit, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+
+        # hud 1-5
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
+            ([
+                [],
+                "{0} + {1} | 删除选中的击杀球".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
+                "{0} + {1} | 删除选中的弹球".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
+                [],
+                "{0} + {1} | 删除选中的传送门".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE))
+            ][EditorMode.current]
+            ) checkCN
+            ([
+                [],
+                "{0} + {1} | delete selected".format(buttonString(Button.INTERACT),  buttonString(Button.SECONDARY_FIRE)),
+                "{0} + {1} | delete selected".format(buttonString(Button.INTERACT),  buttonString(Button.SECONDARY_FIRE)),
+                [],
+                "{0} + {1} | delete selected".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
+            ][EditorMode.current]),
+            HudPosition.RIGHT, HO.edit_instructions_edit1, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+
+        # hud 2
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide else null,
         ([
-            "{0} + {1} | Create New\n"
-            "{0} + {2} | Delete selected".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
+                "{0} + {1} | 移除/新建传送点\n"
+                "{0} + {2} | 检查点碰撞模型\n".format(buttonString(Button.INTERACT) , buttonString(Button.RELOAD), buttonString(Button.ABILITY_1)),
 
-            "{0} + {1} | Create new\n"
-            "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | 选择上一个击杀球\n"
+                "{0} + {2} | 选择下一个击杀球\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-            "{0} + {1} | Create new\n"
-            "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | 选择上一个弹球\n"
+                "{0} + {2} | 选择下一个弹球\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-            "{0} + {1} | multiclimb\n"
-            "{0} + {2} | createbhop".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)
-            ),
-            "{0} + {1} | create new\n"
-            "{0} + {1} (hold)| raycast new".format(buttonString(Button.INTERACT), buttonString(Button.PRIMARY_FIRE)),
-        ][EditorMode.current] if not EditorMoveItem else
-            "walk | move selected\n"
-            "{0} | move up\n"
-            "{1} | move down\n"
-            "{2} (hold) | move faster".format(buttonString(Button.ABILITY_2), buttonString(Button.ULTIMATE), buttonString(Button.JUMP))),
-        HudPosition.RIGHT, HO.edit_instructions_edit, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+                "{0} + {1} | 爬墙\n"
+                "{0} + {2} | 延二段跳".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-    # hud 1-5
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
-        ([
-            [],
-            "{0} + {1} | 删除选中的击杀球".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
-            "{0} + {1} | 删除选中的弹球".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
-            [],
-            "{0} + {1} | 删除选中的传送门".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE))
-        ][EditorMode.current]
-        ) checkCN
-        ([
-            [],
-            "{0} + {1} | delete selected".format(buttonString(Button.INTERACT),  buttonString(Button.SECONDARY_FIRE)),
-            "{0} + {1} | delete selected".format(buttonString(Button.INTERACT),  buttonString(Button.SECONDARY_FIRE)),
-            [],
-            "{0} + {1} | delete selected".format(buttonString(Button.INTERACT), buttonString(Button.SECONDARY_FIRE)),
-        ][EditorMode.current]),
-        HudPosition.RIGHT, HO.edit_instructions_edit1, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+                "{0} + {1} | 选择下一个传送门\n"
+                "{0} + {2} | 选择上一个传送门\n".format(buttonString(Button.INTERACT), buttonString(Button.JUMP), buttonString(Button.CROUCH))
+            ][EditorMode.current] if not EditorMoveItem else
+                #"{0} (长按) | 快速移动"
+                "{0} | 放置实体"
+                "{1} | cancel placement\n".format(buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE))
+            ) checkCN
+            ([
+                "{0} + {1} | Remove/Add teleport\n"
+                "{0} + {2} | Toggle Hitbox\n".format(buttonString(Button.INTERACT) , buttonString(Button.RELOAD), buttonString(Button.ABILITY_1)),
 
-    # hud 2
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide else null,
-      ([
-            "{0} + {1} | 移除/新建传送点\n"
-            "{0} + {2} | 检查点碰撞模型\n".format(buttonString(Button.INTERACT) , buttonString(Button.RELOAD), buttonString(Button.ABILITY_1)),
+                "{0} + {1} | Select previous\n"
+                "{0} + {2} | Select next\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-            "{0} + {1} | 选择上一个击杀球\n"
-            "{0} + {2} | 选择下一个击杀球\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | Select previous\n"
+                "{0} + {2} | Select next\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-            "{0} + {1} | 选择上一个弹球\n"
-            "{0} + {2} | 选择下一个弹球\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | wallclimb\n"
+                "{0} + {2} | save double".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
 
-            "{0} + {1} | 爬墙\n"
-            "{0} + {2} | 延二段跳".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | select next\n"
+                "{0} + {2} | select previous\n".format(buttonString(Button.INTERACT), buttonString(Button.JUMP), buttonString(Button.CROUCH))
+            ][EditorMode.current] if not EditorMoveItem else
+                "{0} | confirm placement\n"
+                "{1} | cancel placement".format(buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE))),
+            HudPosition.RIGHT, HO.edit_instructions_edit2, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-            "{0} + {1} | 选择下一个传送门\n"
-            "{0} + {2} | 选择上一个传送门\n".format(buttonString(Button.INTERACT), buttonString(Button.JUMP), buttonString(Button.CROUCH))
-        ][EditorMode.current] if not EditorMoveItem else
-            #"{0} (长按) | 快速移动"
-            "{0} | 放置实体"
-            "{1} | cancel placement\n".format(buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE))
-        ) checkCN
-        ([
-            "{0} + {1} | Remove/Add teleport\n"
-            "{0} + {2} | Toggle Hitbox\n".format(buttonString(Button.INTERACT) , buttonString(Button.RELOAD), buttonString(Button.ABILITY_1)),
+        # hud3
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
+            ([
+                "{0} (长按) | 移动检查点".format(buttonString(Button.ABILITY_2)),
+                "{0} + {1} | 增大击杀球\n"
+                "{0} + {2} | 缩小击杀球".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP), buttonString(Button.CROUCH)),
 
-            "{0} + {1} | Select previous\n"
-            "{0} + {2} | Select next\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | 增加弹球弹力\n"
+                "{0} + {2} | 减少弹球弹力".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP),buttonString(Button.CROUCH)),
 
-            "{0} + {1} | Select previous\n"
-            "{0} + {2} | Select next\n".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | 死小\n"
+                "{0} + {2} | 表情留小".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
 
-            "{0} + {1} | wallclimb\n"
-            "{0} + {2} | save double".format(buttonString(Button.INTERACT), buttonString(Button.CROUCH), buttonString(Button.JUMP)),
+                "{0} + {1} | 移动选中的实体\n"
+                "{0} + {2} | 应用到当前/所有关卡(开关)".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.JUMP))
+            ][EditorMode.current]
+            ) checkCN
+            ([
+                "{0} (hold) | Move".format(buttonString(Button.ABILITY_2)),
+                "{0} + {1} | Increase size\n"
+                "{0} + {2} | Decrease size".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP), buttonString(Button.CROUCH)),
 
-            "{0} + {1} | select next\n"
-            "{0} + {2} | select previous\n".format(buttonString(Button.INTERACT), buttonString(Button.JUMP), buttonString(Button.CROUCH))
-        ][EditorMode.current] if not EditorMoveItem else
-            "{0} | confirm placement\n"
-            "{1} | cancel placement".format(buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE))),
-        HudPosition.RIGHT, HO.edit_instructions_edit2, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+                "{0} + {1} | Increase strength\n"
+                "{0} + {2} | Decrease strength".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP),buttonString(Button.CROUCH)),
 
-    # hud3
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
-        ([
-            "{0} (长按) | 移动检查点".format(buttonString(Button.ABILITY_2)),
-            "{0} + {1} | 增大击杀球\n"
-            "{0} + {2} | 缩小击杀球".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP), buttonString(Button.CROUCH)),
+                "{0} + {1} | death hop\n"
+                "{0} + {2} | emote".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
 
-            "{0} + {1} | 增加弹球弹力\n"
-            "{0} + {2} | 减少弹球弹力".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP),buttonString(Button.CROUCH)),
-
-            "{0} + {1} | 死小\n"
-            "{0} + {2} | 表情留小".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
-
-            "{0} + {1} | 移动选中的实体\n"
-            "{0} + {2} | 应用到当前/所有关卡(开关)".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.JUMP))
-        ][EditorMode.current]
-        ) checkCN
-        ([
-            "{0} (hold) | Move".format(buttonString(Button.ABILITY_2)),
-            "{0} + {1} | Increase size\n"
-            "{0} + {2} | Decrease size".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP), buttonString(Button.CROUCH)),
-
-            "{0} + {1} | Increase strength\n"
-            "{0} + {2} | Decrease strength".format(buttonString(Button.ABILITY_2), buttonString(Button.JUMP),buttonString(Button.CROUCH)),
-
-            "{0} + {1} | death hop\n"
-            "{0} + {2} | emote".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE)),
-
-            "{0} + {1} | move\n"
-            "{0} + {2} | cp/map (toggle)".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.JUMP))
-        ][EditorMode.current]),
-        HudPosition.RIGHT, HO.edit_instructions_edit3, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    # hud4
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
-        ([
-            [],
-            "{0} + {1} | 移动选中的实体".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)),
-            "{0} + {1} | 移动选中的实体".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)),
-            "{0} + {1} | 留小跳进点\n"
-            "{0} + {2} | 站卡".format(buttonString(Button.ABILITY_2) , buttonString(Button.JUMP), buttonString(Button.CROUCH)),
-            []
-        ][EditorMode.current]
-        ) checkCN
-        ([
-            [],
-            "{0} + {1} | Move".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)  ),
-            "{0} + {1} | Move".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE) ),
-            "{0} + {1} | require bhop\n"
-            "{0} + {2} | stand create".format(buttonString(Button.ABILITY_2) , buttonString(Button.JUMP), buttonString(Button.CROUCH)),
-            []
-        ][EditorMode.current]),
-        HudPosition.RIGHT, HO.edit_instructions_edit4, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    # ==
-    /*
-    hudSubtext(
-        hostPlayer if hostPlayer.toggle_guide else null,
-        " \n{0} + {1} | 下一关\n"
-        "{0} + {2} | 上一关\n"
-        "{3} (长按) | 飞行\n".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE), buttonString(Button.ABILITY_1))
-        checkCN
-        " \n{0} + {1} | Next checkpoint\n"
-        "{0} + {2} | Prev checkpoint\n"
-        "{3} (hold)| Fly\n".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE), buttonString(Button.ABILITY_1))
-        ,HudPosition.RIGHT, HO.edit_instructions_general, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE, HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
-    */
-    hudSubtext(
-        hostPlayer if hostPlayer.toggle_guide else null,
-        " \n{0} + {1} | 下一关".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE))
-        #"{0} + {2} | 上一关"
-        checkCN
-        " \n{0} + {1} | Next checkpoint".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE)),
-        #"{0} + {2} | Prev checkpoint"
-        HudPosition.RIGHT, HO.edit_instructions_general, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE,
-        HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
-
-    hudSubtext(
-        hostPlayer if hostPlayer.toggle_guide else null,
-        "{1} + {2} | 上一关\n"
-        "{0} (长按) | 飞行\n".format(buttonString(Button.ABILITY_1), buttonString(Button.CROUCH),buttonString(Button.SECONDARY_FIRE))
-        checkCN
-        "{1} + {2} | Prev checkpoint\n"
-        "{0} (hold)| Fly\n".format(buttonString(Button.ABILITY_1), buttonString(Button.CROUCH),buttonString(Button.SECONDARY_FIRE)),
-        HudPosition.RIGHT, HO.edit_instructions_general1, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE,
-        HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
-
-    hudSubheader(hostPlayer if hostPlayer.toggle_guide else null,
-        "保存地图长按 {0} + {1} + {2} 后按弹出窗口的提示进行操作" LeftAlign96.format(buttonString(Button.INTERACT), buttonString(Button.MELEE), buttonString(Button.RELOAD))
-        checkCN
-        "to save map, hold {0} + {1} + {2} then follow instructions" LeftAlign96.format(buttonString(Button.INTERACT), buttonString(Button.MELEE), buttonString(Button.RELOAD)),
-        HudPosition.LEFT, HO.edit_savemap, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-
-    hudText(localPlayer if not localPlayer.editor_saveCache else null,
-        (   "{0} 检查点模式\n"
-            "{1} 击杀球模式\n"
-            "{2} 弹球模式\n"
-            "{3} 封禁(单关)\n"
-            "{4} 自定义传送门 ".format(
-                iconString(Icon.ARROW_RIGHT) if EditorMode.checkpoint else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.killBall else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.functionOrb else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.skillBan else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.portal else "     ")
-        if hostPlayer.isHoldingButton(Button.MELEE) else
-            " {1} {0} ".format(
-                ["检查点模式" ,"击杀球模式","弹球模式","封禁(单关)","自定义传送门"][EditorMode.current],
-                [iconString(Icon.FLAG), iconString(Icon.SKULL), iconString(Icon.MOON), iconString(Icon.STOP), iconString(Icon.SPIRAL)][EditorMode.current])
-        if localPlayer == hostPlayer else
-            " {0} 源氏 编辑者 {0} ".format( iconString(Icon.BOLT))
-        ) checkCN
-            "{0} checkpoints\n"
-            "{1} boundary spheres\n"
-            "{2} function orbs\n"
-            "{3} skill bans\n"
-            "{4} portals".format(
-                iconString(Icon.ARROW_RIGHT) if EditorMode.checkpoint else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.killBall else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.functionOrb else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.skillBan else "     ",
-                iconString(Icon.ARROW_RIGHT) if EditorMode.portal else "     ")
-        if hostPlayer.isHoldingButton(Button.MELEE) else
-            " {1} {0} ".format(
-                ["checkpoints" ,"boundary spheres","function orbs","skill bans","portals"][EditorMode.current],
-                [iconString(Icon.FLAG), iconString(Icon.SKULL), iconString(Icon.MOON), iconString(Icon.STOP),iconString(Icon.SPIRAL)][EditorMode.current])
-        if localPlayer == hostPlayer else
-            " {0} Genji editor {0} ".format(iconString(Icon.BOLT)),
-        null,
-        null,
-        HudPosition.TOP, HO.edit_host_mode, Color.BLUE, Color.BLUE, Color.BLUE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-
-    hudText(true[0],
-        null,  # original part of the one ontop of it
-        ("{0} + 射击 | 切换作图模式".format(buttonString(Button.MELEE)) if localPlayer == hostPlayer else
-        "房主/编辑者 {0}".format(hostPlayer))
-        checkCN
-        ("{0} + shoot | change mode".format(buttonString(Button.MELEE)) if localPlayer == hostPlayer else
-        "Current host/editor: {0}".format(hostPlayer)),
-        null,
-        HudPosition.TOP,
-        HO.edit_changemode,
-        Color.SKY_BLUE,
-        Color.GRAY if localPlayer.editor_lock else Color.WHITE,
-        Color.WHITE,
-        HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
-
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide and (EditorMode.checkpoint or EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)) else null, #if EditorMode.checkpoint or EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
-        "{0} + {1} | {4} {3} | {2}" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.PRIMARY_FIRE),
-            (BounceToggleUlt[EditSelected]) if EditorMode.functionOrb else
-            (hostPlayer.checkpoint_current in BladeEnabledCheckpoints),
-            abilityIconString(Hero.GENJI, Button.ULTIMATE),
-            "检查点给刀"  if EditorMode.checkpoint else "弹球给刀"
+                "{0} + {1} | move\n"
+                "{0} + {2} | cp/map (toggle)".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE), buttonString(Button.JUMP))
+            ][EditorMode.current]),
+            HudPosition.RIGHT, HO.edit_instructions_edit3, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+        # hud4
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide and not EditorMoveItem else null,
+            ([
+                [],
+                "{0} + {1} | 移动选中的实体".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | 移动选中的实体".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)),
+                "{0} + {1} | 留小跳进点\n"
+                "{0} + {2} | 站卡".format(buttonString(Button.ABILITY_2) , buttonString(Button.JUMP), buttonString(Button.CROUCH)),
+                []
+            ][EditorMode.current]
+            ) checkCN
+            ([
+                [],
+                "{0} + {1} | Move".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE)  ),
+                "{0} + {1} | Move".format(buttonString(Button.ABILITY_2), buttonString(Button.PRIMARY_FIRE) ),
+                "{0} + {1} | require bhop\n"
+                "{0} + {2} | stand create".format(buttonString(Button.ABILITY_2) , buttonString(Button.JUMP), buttonString(Button.CROUCH)),
+                []
+            ][EditorMode.current]),
+            HudPosition.RIGHT, HO.edit_instructions_edit4, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+        # ==
+        /*
+        hudSubtext(
+            hostPlayer if hostPlayer.toggle_guide else null,
+            " \n{0} + {1} | 下一关\n"
+            "{0} + {2} | 上一关\n"
+            "{3} (长按) | 飞行\n".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE), buttonString(Button.ABILITY_1))
+            checkCN
+            " \n{0} + {1} | Next checkpoint\n"
+            "{0} + {2} | Prev checkpoint\n"
+            "{3} (hold)| Fly\n".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE), buttonString(Button.SECONDARY_FIRE), buttonString(Button.ABILITY_1))
+            ,HudPosition.RIGHT, HO.edit_instructions_general, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE, HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
         )
-        checkCN
-        "{0} + {1} | {4} give ult {3} | {2}" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.PRIMARY_FIRE),
-            (BounceToggleUlt[EditSelected]) if EditorMode.functionOrb else
-            (hostPlayer.checkpoint_current in BladeEnabledCheckpoints),
-            abilityIconString(Hero.GENJI, Button.ULTIMATE),
-            "Level" if EditorMode.checkpoint  else "Orb"),
-        HudPosition.LEFT, HO.edit_orb_ult,
-        Color.GREEN if BounceToggleUlt[EditSelected] and EditorMode.functionOrb else
-        Color.GREEN if hostPlayer.checkpoint_current in BladeEnabledCheckpoints and EditorMode.checkpoint else Color.ORANGE,
-        HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
+        */
+        hudSubtext(
+            hostPlayer if hostPlayer.toggle_guide else null,
+            " \n{0} + {1} | 下一关".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE))
+            #"{0} + {2} | 上一关"
+            checkCN
+            " \n{0} + {1} | Next checkpoint".format(buttonString(Button.CROUCH), buttonString(Button.PRIMARY_FIRE)),
+            #"{0} + {2} | Prev checkpoint"
+            HudPosition.RIGHT, HO.edit_instructions_general, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE,
+            HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
 
-    hudSubtext(hostPlayer if hostPlayer.toggle_guide and (EditorMode.checkpoint or EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)) else null, #if EditorMode.checkpoint or EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
-        "{0} + {1} | {4} {3} | {2}" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.SECONDARY_FIRE),
-            BounceToggleDash[EditSelected] if EditorMode.functionOrb else
-            hostPlayer.checkpoint_current in DashEnabledCheckpoints,
-            abilityIconString(Hero.GENJI, Button.ABILITY_1),
-           "检查点给Shift" if EditorMode.checkpoint else "弹球给Shift")
-        checkCN
-        "{0} + {1} | {4} give dash {3} | {2}" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.SECONDARY_FIRE),
-            BounceToggleDash[EditSelected] if EditorMode.functionOrb else
-            hostPlayer.checkpoint_current in DashEnabledCheckpoints,
-            abilityIconString(Hero.GENJI, Button.ABILITY_1),
-            "Level" if EditorMode.checkpoint else "Orb")
-        , HudPosition.LEFT, HO.edit_orb_dash,
-        Color.GREEN if BounceToggleDash[EditSelected] and EditorMode.functionOrb else
-        Color.GREEN if hostPlayer.checkpoint_current in DashEnabledCheckpoints and EditorMode.checkpoint else Color.ORANGE,
-        HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
+        hudSubtext(
+            hostPlayer if hostPlayer.toggle_guide else null,
+            "{1} + {2} | 上一关\n"
+            "{0} (长按) | 飞行\n".format(buttonString(Button.ABILITY_1), buttonString(Button.CROUCH),buttonString(Button.SECONDARY_FIRE))
+            checkCN
+            "{1} + {2} | Prev checkpoint\n"
+            "{0} (hold)| Fly\n".format(buttonString(Button.ABILITY_1), buttonString(Button.CROUCH),buttonString(Button.SECONDARY_FIRE)),
+            HudPosition.RIGHT, HO.edit_instructions_general1, Color.GREEN if hostPlayer.toggle_guide else Color.ORANGE,
+            HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
 
-    hudSubtext(hostPlayer if EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
-        "{0} + {1} |  收集球(进点前必须集齐) {3} | {2}\n" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.ABILITY_2),
-            BounceToggleLock[EditSelected],
-            iconString(Icon.ASTERISK))
-        checkCN
-        "{0} + {1} | unlocks checkpoint {3} | {2}\n" LeftAlign96.format(
-            buttonString(Button.ULTIMATE),
-            buttonString(Button.ABILITY_2),
-            BounceToggleLock[EditSelected],
-            iconString(Icon.ASTERISK)),
-        HudPosition.LEFT, HO.edit_orb_lock, Color.GREEN if BounceToggleLock[EditSelected] else Color.ORANGE, HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
+        hudSubheader(hostPlayer if hostPlayer.toggle_guide else null,
+            "保存地图长按 {0} + {1} + {2} 后按弹出窗口的提示进行操作" LeftAlign96.format(buttonString(Button.INTERACT), buttonString(Button.MELEE), buttonString(Button.RELOAD))
+            checkCN
+            "to save map, hold {0} + {1} + {2} then follow instructions" LeftAlign96.format(buttonString(Button.INTERACT), buttonString(Button.MELEE), buttonString(Button.RELOAD)),
+            HudPosition.LEFT, HO.edit_savemap, Color.YELLOW, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    hudText(hostPlayer if hostPlayer.toggle_guide else null,
-        "球体/传送门上限: {0}/{1} ".format(len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart), fxLimit)
-        checkCN
-        "orb/portal limit: {0}/{1} ".format(len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart), fxLimit),
-        null, LeftAlign128, HudPosition.LEFT, HO.edit_orblimit, Color.BLUE, null, null, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
-    )
+        hudText(localPlayer if not localPlayer.editor_saveCache else null,
+            (   "{0} 检查点模式\n"
+                "{1} 击杀球模式\n"
+                "{2} 弹球模式\n"
+                "{3} 封禁(单关)\n"
+                "{4} 自定义传送门 ".format(
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.checkpoint else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.killBall else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.functionOrb else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.skillBan else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.portal else "     ")
+            if hostPlayer.isHoldingButton(Button.MELEE) else
+                " {1} {0} ".format(
+                    ["检查点模式" ,"击杀球模式","弹球模式","封禁(单关)","自定义传送门"][EditorMode.current],
+                    [iconString(Icon.FLAG), iconString(Icon.SKULL), iconString(Icon.MOON), iconString(Icon.STOP), iconString(Icon.SPIRAL)][EditorMode.current])
+            if localPlayer == hostPlayer else
+                " {0} 源氏 编辑者 {0} ".format( iconString(Icon.BOLT))
+            ) checkCN
+                "{0} checkpoints\n"
+                "{1} boundary spheres\n"
+                "{2} function orbs\n"
+                "{3} skill bans\n"
+                "{4} portals".format(
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.checkpoint else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.killBall else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.functionOrb else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.skillBan else "     ",
+                    iconString(Icon.ARROW_RIGHT) if EditorMode.portal else "     ")
+            if hostPlayer.isHoldingButton(Button.MELEE) else
+                " {1} {0} ".format(
+                    ["checkpoints" ,"boundary spheres","function orbs","skill bans","portals"][EditorMode.current],
+                    [iconString(Icon.FLAG), iconString(Icon.SKULL), iconString(Icon.MOON), iconString(Icon.STOP),iconString(Icon.SPIRAL)][EditorMode.current])
+            if localPlayer == hostPlayer else
+                " {0} Genji editor {0} ".format(iconString(Icon.BOLT)),
+            null,
+            null,
+            HudPosition.TOP, HO.edit_host_mode, Color.BLUE, Color.BLUE, Color.BLUE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    # display selected cc/orb info
-    hudText(hostPlayer if hostPlayer.toggle_guide else null,
-        (
-            "\n 选中的检查点 \n 矢量: {0}{1} \n".format(
-                CheckpointPositions[hostPlayer.checkpoint_current],
-                [] if len(CheckpointPositions[hostPlayer.checkpoint_current]) < 2 else
-                "\n 传送点: {0}".format(CheckpointPositions[hostPlayer.checkpoint_current][1]))
-            if EditorMode.checkpoint and len(CheckpointPositions) else
-            "\n 选中的击杀球"
-            "\n 矢量: {}"
-            "\n 半径: {}"
-            "\n  + 進不去"
-            "\n  - 出不來"
-            "\n".format(
-                KillBallPositions[EditSelected],
-                KillBallRadii[EditSelected])
-            if EditorMode.killBall and len(hostPlayer.editor_killIndex) else
-            "\n 选中的弹球"
-            "\n 矢量: {1}"
-            "\n 弹力: {0}"
-            "\n 序号: {2}\n".format(
-                BounceStrength[EditSelected],
-                BouncePositions[EditSelected],
-                EditSelected)
-            if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex) else
-            "\n 封禁(单关)\n"
-            "――――――――――――\n"
-            " {} 蹭留 ∞\n"
-            " {} 卡小 ♂\n"
-            " {} 站卡 ♠\n"
-            " {} 爬墙 ↑\n"
-            " {} 死小 X\n"
-            " {} 表情留小 ♥\n"
-            " {} 延二段跳 △\n"
-            "――――――――――――\n"
-            " {} 留小跳进点 ≥\n".format(
-                "√" if hostPlayer.checkpoint_current in BanMulti else [],
-                "√" if hostPlayer.checkpoint_current in BanCreate else [],
-                "√" if hostPlayer.checkpoint_current in BanStand else [],
-                "√" if hostPlayer.checkpoint_current in BanClimb else [],
-                "√" if hostPlayer.checkpoint_current in BanDead else [],
-                "√" if hostPlayer.checkpoint_current in BanEmote else [],
-                "√" if hostPlayer.checkpoint_current in BanSaveDouble else [],
-                "√" if hostPlayer.checkpoint_current in BanBhop else []
+        hudText(true[0],
+            null,  # original part of the one ontop of it
+            ("{0} + 射击 | 切换作图模式".format(buttonString(Button.MELEE)) if localPlayer == hostPlayer else
+            "房主/编辑者 {0}".format(hostPlayer))
+            checkCN
+            ("{0} + shoot | change mode".format(buttonString(Button.MELEE)) if localPlayer == hostPlayer else
+            "Current host/editor: {0}".format(hostPlayer)),
+            null,
+            HudPosition.TOP,
+            HO.edit_changemode,
+            Color.SKY_BLUE,
+            Color.GRAY if localPlayer.editor_lock else Color.WHITE,
+            Color.WHITE,
+            HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
+
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide and (EditorMode.checkpoint or EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)) else null, #if EditorMode.checkpoint or EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
+            "{0} + {1} | {4} {3} | {2}" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.PRIMARY_FIRE),
+                (BounceToggleUlt[EditSelected]) if EditorMode.functionOrb else
+                (hostPlayer.checkpoint_current in BladeEnabledCheckpoints),
+                abilityIconString(Hero.GENJI, Button.ULTIMATE),
+                "检查点给刀"  if EditorMode.checkpoint else "弹球给刀"
             )
-            if EditorMode.skillBan else
-                "\n 入口矢量: {}\n"
-                " 出口矢量: {}\n"
-                " 应用关卡: {}\n".format(
-                CustomPortalStart[EditSelected],
-                CustomPortalEndpoint[EditSelected],
-                "所有" if CustomPortalCP[EditSelected] < 0 else hostPlayer.checkpoint_current)
-            if EditorMode.portal and CustomPortalCP[EditSelected] in [hostPlayer.checkpoint_current, -1] and len(CustomPortalCP) else
-            "\n   当前无数据选中   \n"
-        ) checkCN
-        (
-            "\n Selected Checkpoint\n Vector: {0}{1} \n".format(
-                CheckpointPositions[hostPlayer.checkpoint_current],
-                [] if len(CheckpointPositions[hostPlayer.checkpoint_current]) < 2 else
-                "\n Teleport: {0}".format(CheckpointPositions[hostPlayer.checkpoint_current][1]))
-            if EditorMode.checkpoint and len(CheckpointPositions) else
-            "\n Selected boundary sphere"
-            "\n Vector: {}"
-            "\n radius: {}"
-            "\n  + keep out"
-            "\n  - stay in\n".format(KillBallPositions[EditSelected], KillBallRadii[EditSelected])
-            if EditorMode.killBall and len(hostPlayer.editor_killIndex) else
-            "\n Selected Bounce Orb\n Vector: {1}\n strength: {0} \n ID: {2}\n".format(
-                BounceStrength[EditSelected],
-                BouncePositions[EditSelected],
-                EditSelected)
-            if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)  else
-            "\n skill bans\n"
-            "――――――――――――\n"
-            " {} multi-climb ∞\n"
-            " {} create ♂\n"
-            " {} stand ♠\n"
-            " {} climb ↑\n"
-            " {} dead X\n"
-            " {} emote ♥\n"
-            " {} save double △\n"
-            "――――――――――――\n"
-            " {} require bhop ≥\n".format(
-                "√" if hostPlayer.checkpoint_current in BanMulti else [],
-                "√" if hostPlayer.checkpoint_current in BanCreate else [],
-                "√" if hostPlayer.checkpoint_current in BanStand else [],
-                "√" if hostPlayer.checkpoint_current in BanClimb else [],
-                "√" if hostPlayer.checkpoint_current in BanDead else [],
-                "√" if hostPlayer.checkpoint_current in BanEmote else [],
-                "√" if hostPlayer.checkpoint_current in BanSaveDouble else [],
-                "√" if hostPlayer.checkpoint_current in BanBhop else [])
-            if EditorMode.skillBan else
-                "\n Start: {} \n"
-                " End: {} \n"
-                " CP: {} \n".format(
-                CustomPortalStart[EditSelected],
-                CustomPortalEndpoint[EditSelected],
-                "All" if CustomPortalCP[EditSelected] < 0 else hostPlayer.checkpoint_current)
-            if EditorMode.portal and CustomPortalCP[EditSelected] in [hostPlayer.checkpoint_current, -1] and len(CustomPortalCP) else
-            "\n   No data selected   \n"
-        )
-        , null, LeftAlign128, HudPosition.LEFT, HO.edit_selecteddata, Color.WHITE, Color.ORANGE,Color.ORANGE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
-    )
+            checkCN
+            "{0} + {1} | {4} give ult {3} | {2}" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.PRIMARY_FIRE),
+                (BounceToggleUlt[EditSelected]) if EditorMode.functionOrb else
+                (hostPlayer.checkpoint_current in BladeEnabledCheckpoints),
+                abilityIconString(Hero.GENJI, Button.ULTIMATE),
+                "Level" if EditorMode.checkpoint  else "Orb"),
+            HudPosition.LEFT, HO.edit_orb_ult,
+            Color.GREEN if BounceToggleUlt[EditSelected] and EditorMode.functionOrb else
+            Color.GREEN if hostPlayer.checkpoint_current in BladeEnabledCheckpoints and EditorMode.checkpoint else Color.ORANGE,
+            HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
 
-    wait(1)
-    # effects ==========================================================================================================================================================================
-    createInWorldText(
-        true if len(EditSelectIdArray) else null,
-        "选中的实体" checkCN "selected",
-        KillBallPositions[EditSelected] if EditorMode.killBall else
-        BouncePositions[EditSelected] if EditorMode.functionOrb else
-        CustomPortalStart[EditSelected] if EditorMode.portal else
-        null,
-        1.2, Clip.NONE, WorldTextReeval.VISIBILITY_AND_POSITION, Color.ORANGE, SpecVisibility.DEFAULT)
+        hudSubtext(hostPlayer if hostPlayer.toggle_guide and (EditorMode.checkpoint or EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)) else null, #if EditorMode.checkpoint or EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
+            "{0} + {1} | {4} {3} | {2}" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.SECONDARY_FIRE),
+                BounceToggleDash[EditSelected] if EditorMode.functionOrb else
+                hostPlayer.checkpoint_current in DashEnabledCheckpoints,
+                abilityIconString(Hero.GENJI, Button.ABILITY_1),
+            "检查点给Shift" if EditorMode.checkpoint else "弹球给Shift")
+            checkCN
+            "{0} + {1} | {4} give dash {3} | {2}" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.SECONDARY_FIRE),
+                BounceToggleDash[EditSelected] if EditorMode.functionOrb else
+                hostPlayer.checkpoint_current in DashEnabledCheckpoints,
+                abilityIconString(Hero.GENJI, Button.ABILITY_1),
+                "Level" if EditorMode.checkpoint else "Orb")
+            , HudPosition.LEFT, HO.edit_orb_dash,
+            Color.GREEN if BounceToggleDash[EditSelected] and EditorMode.functionOrb else
+            Color.GREEN if hostPlayer.checkpoint_current in DashEnabledCheckpoints and EditorMode.checkpoint else Color.ORANGE,
+            HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
 
-    createIcon(
-        true if len(EditSelectIdArray) else null,
-        KillBallPositions[EditSelected] if EditorMode.killBall else
-        BouncePositions[EditSelected] if EditorMode.functionOrb else
-        CustomPortalStart[EditSelected] if EditorMode.portal else
-        null,
-        Icon.ARROW_DOWN,
-        IconReeval.VISIBILITY_AND_POSITION, Color.WHITE, true)
+        hudSubtext(hostPlayer if EditorMode.functionOrb and hostPlayer.toggle_guide and len(hostPlayer.editor_bounceIndex) else null,
+            "{0} + {1} |  收集球(进点前必须集齐) {3} | {2}\n" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.ABILITY_2),
+                BounceToggleLock[EditSelected],
+                iconString(Icon.ASTERISK))
+            checkCN
+            "{0} + {1} | unlocks checkpoint {3} | {2}\n" LeftAlign96.format(
+                buttonString(Button.ULTIMATE),
+                buttonString(Button.ABILITY_2),
+                BounceToggleLock[EditSelected],
+                iconString(Icon.ASTERISK)),
+            HudPosition.LEFT, HO.edit_orb_lock, Color.GREEN if BounceToggleLock[EditSelected] else Color.ORANGE, HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
 
-    # Purple sphere for teleport location
-    createEffect(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.checkpoint_current][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+        hudText(hostPlayer if hostPlayer.toggle_guide else null,
+            "球体/传送门上限: {0}/{1} ".format(len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart), fxLimit)
+            checkCN
+            "orb/portal limit: {0}/{1} ".format(len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart), fxLimit),
+            null, LeftAlign128, HudPosition.LEFT, HO.edit_orblimit, Color.BLUE, null, null, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    # Teleport text
-    createInWorldText(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.checkpoint_current][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+        # display selected cc/orb info
+        hudText(hostPlayer if hostPlayer.toggle_guide else null,
+            (
+                "\n 选中的检查点 \n 矢量: {0}{1} \n".format(
+                    CheckpointPositions[hostPlayer.checkpoint_current],
+                    [] if len(CheckpointPositions[hostPlayer.checkpoint_current]) < 2 else
+                    "\n 传送点: {0}".format(CheckpointPositions[hostPlayer.checkpoint_current][1]))
+                if EditorMode.checkpoint and len(CheckpointPositions) else
+                "\n 选中的击杀球"
+                "\n 矢量: {}"
+                "\n 半径: {}"
+                "\n  + 進不去"
+                "\n  - 出不來"
+                "\n".format(
+                    KillBallPositions[EditSelected],
+                    KillBallRadii[EditSelected])
+                if EditorMode.killBall and len(hostPlayer.editor_killIndex) else
+                "\n 选中的弹球"
+                "\n 矢量: {1}"
+                "\n 弹力: {0}"
+                "\n 序号: {2}\n".format(
+                    BounceStrength[EditSelected],
+                    BouncePositions[EditSelected],
+                    EditSelected)
+                if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex) else
+                "\n 封禁(单关)\n"
+                "――――――――――――\n"
+                " {} 蹭留 ∞\n"
+                " {} 卡小 ♂\n"
+                " {} 站卡 ♠\n"
+                " {} 爬墙 ↑\n"
+                " {} 死小 X\n"
+                " {} 表情留小 ♥\n"
+                " {} 延二段跳 △\n"
+                "――――――――――――\n"
+                " {} 留小跳进点 ≥\n".format(
+                    "√" if hostPlayer.checkpoint_current in BanMulti else [],
+                    "√" if hostPlayer.checkpoint_current in BanCreate else [],
+                    "√" if hostPlayer.checkpoint_current in BanStand else [],
+                    "√" if hostPlayer.checkpoint_current in BanClimb else [],
+                    "√" if hostPlayer.checkpoint_current in BanDead else [],
+                    "√" if hostPlayer.checkpoint_current in BanEmote else [],
+                    "√" if hostPlayer.checkpoint_current in BanSaveDouble else [],
+                    "√" if hostPlayer.checkpoint_current in BanBhop else []
+                )
+                if EditorMode.skillBan else
+                    "\n 入口矢量: {}\n"
+                    " 出口矢量: {}\n"
+                    " 应用关卡: {}\n".format(
+                    CustomPortalStart[EditSelected],
+                    CustomPortalEndpoint[EditSelected],
+                    "所有" if CustomPortalCP[EditSelected] < 0 else hostPlayer.checkpoint_current)
+                if EditorMode.portal and CustomPortalCP[EditSelected] in [hostPlayer.checkpoint_current, -1] and len(CustomPortalCP) else
+                "\n   当前无数据选中   \n"
+            ) checkCN
+            (
+                "\n Selected Checkpoint\n Vector: {0}{1} \n".format(
+                    CheckpointPositions[hostPlayer.checkpoint_current],
+                    [] if len(CheckpointPositions[hostPlayer.checkpoint_current]) < 2 else
+                    "\n Teleport: {0}".format(CheckpointPositions[hostPlayer.checkpoint_current][1]))
+                if EditorMode.checkpoint and len(CheckpointPositions) else
+                "\n Selected boundary sphere"
+                "\n Vector: {}"
+                "\n radius: {}"
+                "\n  + keep out"
+                "\n  - stay in\n".format(KillBallPositions[EditSelected], KillBallRadii[EditSelected])
+                if EditorMode.killBall and len(hostPlayer.editor_killIndex) else
+                "\n Selected Bounce Orb\n Vector: {1}\n strength: {0} \n ID: {2}\n".format(
+                    BounceStrength[EditSelected],
+                    BouncePositions[EditSelected],
+                    EditSelected)
+                if EditorMode.functionOrb and len(hostPlayer.editor_bounceIndex)  else
+                "\n skill bans\n"
+                "――――――――――――\n"
+                " {} multi-climb ∞\n"
+                " {} create ♂\n"
+                " {} stand ♠\n"
+                " {} climb ↑\n"
+                " {} dead X\n"
+                " {} emote ♥\n"
+                " {} save double △\n"
+                "――――――――――――\n"
+                " {} require bhop ≥\n".format(
+                    "√" if hostPlayer.checkpoint_current in BanMulti else [],
+                    "√" if hostPlayer.checkpoint_current in BanCreate else [],
+                    "√" if hostPlayer.checkpoint_current in BanStand else [],
+                    "√" if hostPlayer.checkpoint_current in BanClimb else [],
+                    "√" if hostPlayer.checkpoint_current in BanDead else [],
+                    "√" if hostPlayer.checkpoint_current in BanEmote else [],
+                    "√" if hostPlayer.checkpoint_current in BanSaveDouble else [],
+                    "√" if hostPlayer.checkpoint_current in BanBhop else [])
+                if EditorMode.skillBan else
+                    "\n Start: {} \n"
+                    " End: {} \n"
+                    " CP: {} \n".format(
+                    CustomPortalStart[EditSelected],
+                    CustomPortalEndpoint[EditSelected],
+                    "All" if CustomPortalCP[EditSelected] < 0 else hostPlayer.checkpoint_current)
+                if EditorMode.portal and CustomPortalCP[EditSelected] in [hostPlayer.checkpoint_current, -1] and len(CustomPortalCP) else
+                "\n   No data selected   \n"
+            ),
+            null, LeftAlign128, HudPosition.LEFT, HO.edit_selecteddata, Color.WHITE, Color.ORANGE,Color.ORANGE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
-    # normal cp if teleport
-    createEffect(hostPlayer if CheckpointPositions[hostPlayer.checkpoint_current][1] and EditorMode.checkpoint else null, Effect.RING, Color.ORANGE, CheckpointPositions[hostPlayer.checkpoint_current][0], 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
-    createInWorldText(hostPlayer if CheckpointPositions[hostPlayer.checkpoint_current][1] and EditorMode.checkpoint else null, "检查点位置" checkCN "level location", CheckpointPositions[hostPlayer.checkpoint_current][0], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+        wait(1)
+        # effects ==========================================================================================================================================================================
+        createInWorldText(
+            true if len(EditSelectIdArray) else null,
+            "选中的实体" checkCN "selected",
+            KillBallPositions[EditSelected] if EditorMode.killBall else
+            BouncePositions[EditSelected] if EditorMode.functionOrb else
+            CustomPortalStart[EditSelected] if EditorMode.portal else
+            null,
+            1.2, Clip.NONE, WorldTextReeval.VISIBILITY_AND_POSITION, Color.ORANGE, SpecVisibility.DEFAULT)
 
-    # portal fx
-    createEffect(hostPlayer if len(EditSelectIdArray) and EditorMode.portal else null, Effect.SPARKLES, Color.PURPLE, CustomPortalEndpoint[EditSelected], 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+        createIcon(
+            true if len(EditSelectIdArray) else null,
+            KillBallPositions[EditSelected] if EditorMode.killBall else
+            BouncePositions[EditSelected] if EditorMode.functionOrb else
+            CustomPortalStart[EditSelected] if EditorMode.portal else
+            null,
+            Icon.ARROW_DOWN,
+            IconReeval.VISIBILITY_AND_POSITION, Color.WHITE, true)
+
+        # Purple sphere for teleport location
+        createEffect(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.checkpoint_current][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+
+        # Teleport text
+        createInWorldText(true if len(CheckpointPositions[hostPlayer.checkpoint_current]) > 1 and EditorMode.checkpoint else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.checkpoint_current][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+
+        # normal cp if teleport
+        createEffect(hostPlayer if CheckpointPositions[hostPlayer.checkpoint_current][1] and EditorMode.checkpoint else null, Effect.RING, Color.ORANGE, CheckpointPositions[hostPlayer.checkpoint_current][0], 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+        createInWorldText(hostPlayer if CheckpointPositions[hostPlayer.checkpoint_current][1] and EditorMode.checkpoint else null, "检查点位置" checkCN "level location", CheckpointPositions[hostPlayer.checkpoint_current][0], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+
+        # portal fx
+        createEffect(hostPlayer if len(EditSelectIdArray) and EditorMode.portal else null, Effect.SPARKLES, Color.PURPLE, CustomPortalEndpoint[EditSelected], 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    else: #Editor Off
+        HudStoreEdit = null # clear variables if not in editor mode
 
 # global functions ==============================================================
 rule "Editor |  Fly/Noclip Toggle":

--- a/editor.opy
+++ b/editor.opy
@@ -923,7 +923,7 @@ rule "Editor | toggle orb functions":
         BounceToggleDash[EditSelected] = not BounceToggleDash[EditSelected]
     else:
         BounceToggleLock[EditSelected] = not BounceToggleLock[EditSelected]
-        BounceStrength[EditSelected] = 10 * BounceToggleLock[EditSelected]
+        BounceStrength[EditSelected] = 10 * not BounceToggleLock[EditSelected]
 
     UpdateCache()
     hostPlayer.editor_lock = false

--- a/effects.opy
+++ b/effects.opy
@@ -46,7 +46,7 @@ rule "Effects | Setup Effects":
         if len(BouncePositions):
             for TempIterator1 in range(0, len(BouncePositions)):
                 createEffect(
-                    #localSpectator(localPlayer.checkpoint_current == BouncePadCheckpoints[evalOnce(TempIterator1)] and not (evalOnce(TempIterator1) in x.cache_collectedLocks)), #$$ Testing
+                    #localSpectator(localPlayer.checkpoint_current == BouncePadCheckpoints[evalOnce(TempIterator1)] and not (evalOnce(TempIterator1) in localPlayer.cache_collectedLocks)), #$$ Testing
                     [x for x in getAllPlayers().concat(0) if x.checkpoint_current == evalOnce(BouncePadCheckpoints[TempIterator1]) and not (evalOnce(TempIterator1) in x.cache_collectedLocks)],
                     Effect.ORB, ColorConfig[Customize.orb_lock] if BounceToggleLock[TempIterator1] else ColorConfig[Customize.orb_normal], BouncePositions[TempIterator1], 1, EffectReeval.VISIBILITY)
                 wait()

--- a/effects.opy
+++ b/effects.opy
@@ -18,9 +18,9 @@ rule "Effects | Setup Effects":
                 PortalNames[TempIterator1],
                 PortalLoc[TempIterator1] + Vector.UP,
                 1, Clip.SURFACES, WorldTextReeval.VISIBILITY, Color.WHITE, SpecVisibility.DEFAULT)
-    waitUntil(entityExists(getAllPlayers()), Math.INFINITY)
     wait()
-    if getAllPlayers()[0].editor_on:
+    waitUntil(entityExists(getAllPlayers()), Math.INFINITY)
+    if getAllPlayers().editor_on:
         RebuildKillOrbs()
         RebuildBounceOrbs()
         RebuildPortals()

--- a/effects.opy
+++ b/effects.opy
@@ -71,7 +71,7 @@ def RebuildBounceOrbs(): # triggers in editor. delets the current orbs to place 
             Effect.ORB,
             ColorConfig[Customize.orb_lock] if BounceToggleLock[evalOnce(TempIterator1)] else ColorConfig[Customize.orb_normal],
             BouncePositions[evalOnce(TempIterator1)],
-            true,
+            1,
             EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR)
         BounceEffects.append(getLastCreatedEntity())
         #wait()

--- a/effects.opy
+++ b/effects.opy
@@ -25,48 +25,42 @@ rule "Effects | Setup Effects":
         RebuildBounceOrbs()
         RebuildPortals()
     else:
-        EffectsCreate()
-
-def EffectsCreate():
-    @Name "Effects | SUB Create Object Effects"
-    if len(CustomPortalStart):
-        for TempIterator1 in range(len(CustomPortalStart)):
-            createEffect(
-                #localSpectator(localPlayer.checkpoint_current == CustomPortalCP[evalOnce(TempIterator1)] or CustomPortalCP[evalOnce(TempIterator1)] == -1), #$$ Testing
-                [i for i in getAllPlayers() if i.checkpoint_current == evalOnce(CustomPortalCP[TempIterator1]) or evalOnce(CustomPortalCP[TempIterator1] < 0)],
-                Effect.GOOD_AURA, ColorConfig[Customize.portal], CustomPortalStart[TempIterator1], 0.6, EffectReeval.VISIBILITY)
-            wait()
-        wait(0.5)
-
-    if len(KillBallPositions):
-        for TempIterator1 in range(0, len(KillBallPositions)):
-            createEffect(
-                #localSpectator(localPlayer.checkpoint_current == KillballCheckpoints[evalOnce(TempIterator1)]), #$$ Testing
-                [x for x in getAllPlayers() if x.checkpoint_current == evalOnce(KillballCheckpoints[TempIterator1])],
-                Effect.SPHERE, ColorConfig[Customize.killorb], KillBallPositions[TempIterator1], abs(KillBallRadii[TempIterator1]), EffectReeval.VISIBILITY)
-            wait()
-        wait(0.5)
-
-    if len(BouncePositions):
-        for TempIterator1 in range(0, len(BouncePositions)):
-            createEffect(
-                #localSpectator(localPlayer.checkpoint_current == BouncePadCheckpoints[evalOnce(TempIterator1)] and not (evalOnce(TempIterator1) in x.cache_collectedLocks)), #$$ Testing
-                [x for x in getAllPlayers().concat(0) if x.checkpoint_current == evalOnce(BouncePadCheckpoints[TempIterator1]) and not (evalOnce(TempIterator1) in x.cache_collectedLocks)],
-                Effect.ORB, ColorConfig[Customize.orb_lock] if BounceToggleLock[TempIterator1] else ColorConfig[Customize.orb_normal], BouncePositions[TempIterator1], 1, EffectReeval.VISIBILITY)
-            wait()
-    # End portal preview
-    createEffect(
-        localPlayer if
-            localPlayer.preview_i and
-            localPlayer.preview_i > len(localPlayer.cache_bouncePosition) and
-            localPlayer.preview_array2[localPlayer.preview_i].last()
-            else null,
-        Effect.SPARKLES,
-        Color.PURPLE,
-        localPlayer.preview_array1[localPlayer.preview_i],
-        0.5, EffectReeval.VISIBILITY_POSITION_AND_RADIUS
-    )
-
+        if len(CustomPortalStart):
+            for TempIterator1 in range(len(CustomPortalStart)):
+                createEffect(
+                    #localSpectator(localPlayer.checkpoint_current == CustomPortalCP[evalOnce(TempIterator1)] or CustomPortalCP[evalOnce(TempIterator1)] == -1), #$$ Testing
+                    [i for i in getAllPlayers() if i.checkpoint_current == evalOnce(CustomPortalCP[TempIterator1]) or evalOnce(CustomPortalCP[TempIterator1] < 0)],
+                    Effect.GOOD_AURA, ColorConfig[Customize.portal], CustomPortalStart[TempIterator1], 0.6, EffectReeval.VISIBILITY)
+                wait()
+            wait(0.5)
+    
+        if len(KillBallPositions):
+            for TempIterator1 in range(0, len(KillBallPositions)):
+                createEffect(
+                    #localSpectator(localPlayer.checkpoint_current == KillballCheckpoints[evalOnce(TempIterator1)]), #$$ Testing
+                    [x for x in getAllPlayers() if x.checkpoint_current == evalOnce(KillballCheckpoints[TempIterator1])],
+                    Effect.SPHERE, ColorConfig[Customize.killorb], KillBallPositions[TempIterator1], abs(KillBallRadii[TempIterator1]), EffectReeval.VISIBILITY)
+                wait()
+            wait(0.5)
+    
+        if len(BouncePositions):
+            for TempIterator1 in range(0, len(BouncePositions)):
+                createEffect(
+                    #localSpectator(localPlayer.checkpoint_current == BouncePadCheckpoints[evalOnce(TempIterator1)] and not (evalOnce(TempIterator1) in x.cache_collectedLocks)), #$$ Testing
+                    [x for x in getAllPlayers().concat(0) if x.checkpoint_current == evalOnce(BouncePadCheckpoints[TempIterator1]) and not (evalOnce(TempIterator1) in x.cache_collectedLocks)],
+                    Effect.ORB, ColorConfig[Customize.orb_lock] if BounceToggleLock[TempIterator1] else ColorConfig[Customize.orb_normal], BouncePositions[TempIterator1], 1, EffectReeval.VISIBILITY)
+                wait()
+        # End portal preview
+        createEffect(
+            localPlayer if
+                localPlayer.preview_i and
+                localPlayer.preview_i > len(localPlayer.cache_bouncePosition) and
+                localPlayer.preview_array2[localPlayer.preview_i].last()
+                else null,
+            Effect.SPARKLES,
+            Color.PURPLE,
+            localPlayer.preview_array1[localPlayer.preview_i], 0.5, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    
 def RebuildBounceOrbs(): # triggers in editor. delets the current orbs to place ones that can be modified. orginal orbs in "SUB | Bounce Ball Effects"
     @Name "Effects | SUB Rebuild Bounce Orbs"
     destroyEffect(BounceEffects)

--- a/effects.opy
+++ b/effects.opy
@@ -71,9 +71,8 @@ def RebuildBounceOrbs(): # triggers in editor. delets the current orbs to place 
             Effect.ORB,
             ColorConfig[Customize.orb_lock] if BounceToggleLock[evalOnce(TempIterator1)] else ColorConfig[Customize.orb_normal],
             BouncePositions[evalOnce(TempIterator1)],
-            1,
-            EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR
-        )
+            true,
+            EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR)
         BounceEffects.append(getLastCreatedEntity())
         #wait()
         if not (TempIterator1 % 5):
@@ -101,8 +100,7 @@ def RebuildPortals():
                 ColorConfig[Customize.portal],
                 CustomPortalStart[evalOnce(TempIterator1)],
                 0.6,
-                EffectReeval.VISIBILITY_POSITION_AND_RADIUS
-            )
+                EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
             PortalEffects.append(getLastCreatedEntity())
             if not (TempIterator1 % 5):
                 wait()

--- a/effects.opy
+++ b/effects.opy
@@ -18,9 +18,9 @@ rule "Effects | Setup Effects":
                 PortalNames[TempIterator1],
                 PortalLoc[TempIterator1] + Vector.UP,
                 1, Clip.SURFACES, WorldTextReeval.VISIBILITY, Color.WHITE, SpecVisibility.DEFAULT)
-    waitUntil(entityExists([i for i in getAllPlayers() if not i.isDummy()]), Math.INFINITY)
+    waitUntil(entityExists(getAllPlayers()), Math.INFINITY)
     wait()
-    if [i for i in getAllPlayers() if not i.isDummy()][0].editor_on:
+    if getAllPlayers()[0].editor_on:
         RebuildKillOrbs()
         RebuildBounceOrbs()
         RebuildPortals()

--- a/framework.opy
+++ b/framework.opy
@@ -3,7 +3,7 @@
 ##!suppressWarnings w_tags #Workshop Settings
 #!suppressWarnings w_lone_else
 ###############################################################################
-#!define versionhere "v1.10.3E"
+#!define versionhere "v1.10.3F"
 #♨ Dev Build Icon
 ###############################################################################
 #!define editortoggle(x) __script__("test-maps/togglescript.js")

--- a/framework.opy
+++ b/framework.opy
@@ -1,7 +1,8 @@
 #!optimizeForSize
 ##!suppressWarnings w_ow2_communicate_bug
-##!suppressWarnings w_tags #Workshop Settings
+##!suppressWarnings w_tags
 #!suppressWarnings w_lone_else
+#!suppressWarnings w_enum_constant
 ###############################################################################
 #!define versionhere "v1.10.3F"
 #♨ Dev Build Icon

--- a/genji.opy
+++ b/genji.opy
@@ -303,9 +303,9 @@ rule "General | Match time":
     pauseMatchTime()
     wait()
     TimeRemaining = 265
-    while TimeRemaining or hostPlayer.editor_saveHud:
+    while TimeRemaining or hostPlayer.editor_saveCache:
         wait(60)
-        if not hostPlayer.editor_saveHud:
+        if not hostPlayer.editor_saveCache:
             TimeRemaining--
             if CompMode:
                 CompTime--

--- a/genji.opy
+++ b/genji.opy
@@ -320,15 +320,17 @@ rule "General | Match time":
 
 rule "General | Player Initialize":
     @Event playerJoined
-    @Condition eventPlayer.isDummy() == false
-    eventPlayer.enableDeathSpectateAllPlayers()
-    eventPlayer.enableDeathSpectateTargetHud()
+    eventPlayer.editor_on = createWorkshopSetting(bool, "map settings \n地图设置","Editor mode - 作图模式" ,  editoron , -1) # Turn Editor On
     eventPlayer.disableGamemodeHud()
     eventPlayer.disablePlayerCollision()
+    eventPlayer.setDamageReceived(0)
+    eventPlayer.lockState = true
+    if eventPlayer.isDummy(): return
+
+    eventPlayer.enableDeathSpectateAllPlayers()
+    eventPlayer.enableDeathSpectateTargetHud()
     eventPlayer.disableRespawn()
     eventPlayer.preloadHero(Hero.GENJI)
-    eventPlayer.setDamageReceived(0)
-    eventPlayer.editor_on = createWorkshopSetting(bool, "map settings \n地图设置","Editor mode - 作图模式" ,  editoron , -1) # Turn Editor On
     eventPlayer.editor_lock = true
     eventPlayer.toggle_guide = true
     eventPlayer.cache_bounceTouched = -1
@@ -362,6 +364,7 @@ rule "General | Player Initialize":
 
     wait()
     StartGame()  # initialization of the game
+    eventPlayer.lockState = false
 
 rule "General | Player Leaves":
     @Event playerLeft
@@ -373,7 +376,7 @@ rule "General | Player Leaves":
 
 rule "General | Ground: Traces, Arrive, & Reset":
     @Event eachPlayer
-    @Condition eventPlayer.isDummy() == false
+    @Condition eventPlayer.lockState == false
     @Condition eventPlayer.isOnGround()
     @Condition eventPlayer.isAlive()
     if not eventPlayer.checkpoint_notLast:
@@ -394,7 +397,7 @@ rule "General | Ground: Traces, Arrive, & Reset":
             wait(0.048)
             playEffect(true[0], DynamicEffect.RING_EXPLOSION, eventPlayer.cache_rainbow, eventPlayer.getPosition(), 1.4)
             wait(0.048)
-    elif eventPlayer.toggle_invincible or (CompMode and not CompTime) or eventPlayer.lockState:
+    elif eventPlayer.toggle_invincible or (CompMode and not CompTime):# or eventPlayer.lockState:
         # Do nothing
     elif distance(eventPlayer, CheckpointPositions[eventPlayer.checkpoint_current + 1]) <= cpcircleradius:
         # arrived ----------------------------------------------------------------------------------------------------
@@ -402,75 +405,66 @@ rule "General | Ground: Traces, Arrive, & Reset":
             smallMessage(eventPlayer, "   ! 进点前需集齐所有收集球 !" checkCN "   ! collect ALL {} orbs to unlock !".format(ColorConfig[Customize.orb_lock]))
             #kill(eventPlayer, null)
             CheckpointFailReset()
-            goto lbl_a
-        if eventPlayer.ban_climb and eventPlayer.skill_usedClimb:
+        elif eventPlayer.ban_climb and eventPlayer.skill_usedClimb:
             smallMessage(eventPlayer, "   爬墙 ↑ 已禁用!" checkCN "   Climb ↑ is banned!")
             CheckpointFailReset()
-            goto lbl_a
-
-        if eventPlayer.ban_bhop and eventPlayer.skill_usedBhop:
+        elif eventPlayer.ban_bhop and eventPlayer.skill_usedBhop:
             smallMessage(eventPlayer, "   ≥ 留小跳进点!" checkCN "   ≥ Must have a bhop to complete!")
             CheckpointFailReset()
-            goto lbl_a
-
-        if eventPlayer.ban_djump and eventPlayer.skill_usedDouble:
+        elif eventPlayer.ban_djump and eventPlayer.skill_usedDouble:
             smallMessage(eventPlayer, "   » 留二段跳!" checkCN "   » Must have a double jump to complete!")
             CheckpointFailReset()
-            goto lbl_a
-
-        eventPlayer.checkpoint_moved = true
-        eventPlayer.checkpoint_current += 1
-        UpdateCache()
-        # remove ult feature disabled for speedruning purposes
-        #if eventPlayer.isUsingUltimate() and not eventPlayer.checkpoint_current in BladeEnabledCheckpoints:
-        #    CheckpointFailReset()
-        if len(CheckpointPositions[eventPlayer.checkpoint_current]) > 1:# teleport cps
-            CheckpointFailReset()
-
-        if eventPlayer.timer_splitDisplay > -Math.INFINITY:
-            eventPlayer.timer_splitDisplay = (eventPlayer.timer_practice if eventPlayer.toggle_practice else eventPlayer.timer_normal) - eventPlayer.timer_split
-        wait()
-        playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
-        playEffect(eventPlayer if CompMode or eventPlayer.toggle_invisible else true, DynamicEffect.RING_EXPLOSION, Color.SKY_BLUE, CheckpointPositions[eventPlayer.checkpoint_current] + vect(0, 1.5, 0), 4)
-        # msg disabled due to annoying new sound
-        #bigMessage(eventPlayer,  "{1} {0}".format(eventPlayer.checkpoint_current, "抵达检查点" checkCN "Arrived at level")   )
-        wait()
-        UpdateTitle()
-        AddonCustomLoadAndReset()
-
-        if eventPlayer.toggle_practice:
-            eventPlayer.timer_split = eventPlayer.timer_practice
         else:
-            eventPlayer.timer_split = eventPlayer.timer_normal
-            DeleteSave()
-            if eventPlayer.checkpoint_current == len(CheckpointPositions) - 1 and not eventPlayer.editor_on: # complete lvl
-                stopChasingVariable(eventPlayer.timer_normal)
-                wait()
-                bigMessage(true[0], "{0} {2} {1}".format(eventPlayer, prettyTime(eventPlayer.timer_normal), "已通关! 用时" checkCN "Mission complete! Time"))
-                LeaderboardUpdate()
-                if CompMode and CompAtmpNum:
-                    if eventPlayer.comp_countAttempts == CompAtmpNum:
-                        CompAtmpSaveCount[CompAtmpSaveNames.index(eventPlayer[0].split([]))] = -1
-                        eventPlayer.comp_countAttempts = -1
-                        eventPlayer.comp_done = true
-                        eventPlayer.toggle_leaderboard = true
-                        #eventPlayer.disableRespawn()
-                        eventPlayer.setDamageReceived(100)
-                        kill(eventPlayer,null)
-                        eventPlayer.setDamageReceived(0)
-                    else:
-                        CompAtmpSaveCount[CompAtmpSaveNames.index(eventPlayer[0].split([]))] = eventPlayer.comp_countAttempts + 1
-            else: # update save
-                MakeSave()
+            eventPlayer.checkpoint_moved = true
+            eventPlayer.checkpoint_current += 1
+            UpdateCache()
+            # remove ult feature disabled for speedruning purposes
+            #if eventPlayer.isUsingUltimate() and not eventPlayer.checkpoint_current in BladeEnabledCheckpoints:
+            #    CheckpointFailReset()
+            if len(CheckpointPositions[eventPlayer.checkpoint_current]) > 1:# teleport cps
+                CheckpointFailReset()
+
+            if eventPlayer.timer_splitDisplay > -Math.INFINITY:
+                eventPlayer.timer_splitDisplay = (eventPlayer.timer_practice if eventPlayer.toggle_practice else eventPlayer.timer_normal) - eventPlayer.timer_split
+            wait()
+            playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
+            playEffect(eventPlayer if CompMode or eventPlayer.toggle_invisible else true, DynamicEffect.RING_EXPLOSION, Color.SKY_BLUE, CheckpointPositions[eventPlayer.checkpoint_current] + vect(0, 1.5, 0), 4)
+            # msg disabled due to annoying new sound
+            #bigMessage(eventPlayer,  "{1} {0}".format(eventPlayer.checkpoint_current, "抵达检查点" checkCN "Arrived at level")   )
+            wait()
+            AddonCustomLoadAndReset()
+
+            if eventPlayer.toggle_practice:
+                eventPlayer.timer_split = eventPlayer.timer_practice
+            else:
+                UpdateTitle()
+                eventPlayer.timer_split = eventPlayer.timer_normal
+                DeleteSave()
+                if eventPlayer.checkpoint_current == len(CheckpointPositions) - 1 and not eventPlayer.editor_on: # complete lvl
+                    stopChasingVariable(eventPlayer.timer_normal)
+                    wait()
+                    bigMessage(true[0], "{0} {2} {1}".format(eventPlayer, prettyTime(eventPlayer.timer_normal), "已通关! 用时" checkCN "Mission complete! Time"))
+                    LeaderboardUpdate()
+                    if CompMode and CompAtmpNum:
+                        if eventPlayer.comp_countAttempts == CompAtmpNum:
+                            CompAtmpSaveCount[CompAtmpSaveNames.index(eventPlayer[0].split([]))] = -1
+                            eventPlayer.comp_countAttempts = -1
+                            eventPlayer.comp_done = true
+                            eventPlayer.toggle_leaderboard = true
+                            #eventPlayer.disableRespawn()
+                            eventPlayer.setDamageReceived(100)
+                            kill(eventPlayer,null)
+                            eventPlayer.setDamageReceived(0)
+                        else:
+                            CompAtmpSaveCount[CompAtmpSaveNames.index(eventPlayer[0].split([]))] = eventPlayer.comp_countAttempts + 1
+                else: # update save
+                    MakeSave()
     elif distance(eventPlayer,CheckpointPositions[eventPlayer.checkpoint_current].last()) > cpcircleradius:
         CheckpointFailReset()
 
-    lbl_a:
     eventPlayer.cache_collectedLocks = []
     wait(0.048)
-
-    if RULE_CONDITION:
-        goto RULE_START
+    if RULE_CONDITION: goto RULE_START
 
 rule "General | Boundary Sphere":
     @Event eachPlayer

--- a/genji.opy
+++ b/genji.opy
@@ -247,7 +247,6 @@ rule "General | Setup & Variables":
     CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else []
 
     LeaderBoardFull = []
-    LeaderBoardRemake = false
     TitleData = null
     HintCp = []
     HintText = []

--- a/genji.opy
+++ b/genji.opy
@@ -63,7 +63,7 @@ def UpdateCache():
     async(CheckUlt(), AsyncBehavior.RESTART)
     async(CheckDash(), AsyncBehavior.RESTART)
 
-    if not eventPlayer.editor_on: return
+    if eventPlayer != hostPlayer or not eventPlayer.editor_on: return
     EditUpdateSelectedIds()
     destroyEffect(eventPlayer.editor_hitboxEffect)
     createEffect(eventPlayer if eventPlayer.editor_hitboxToggle else null, Effect.SPHERE, Color.WHITE, CheckpointPositions[eventPlayer.checkpoint_current], cpcircleradius, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
@@ -72,7 +72,7 @@ def UpdateCache():
     eventPlayer.editor_hitboxEffect.append(getLastCreatedEntity())
     eventPlayer.editor_bounceIndex = [e for e in [(i if e2 == eventPlayer.checkpoint_current else -1) for e2, i in BouncePadCheckpoints] if e >=0]
     eventPlayer.editor_killIndex = [e for e in [(i if e2 == eventPlayer.checkpoint_current else -1) for e2, i in KillballCheckpoints] if e >=0]
-    if eventPlayer.checkpoint_moved and eventPlayer == hostPlayer:
+    if eventPlayer.checkpoint_moved:
         EditorSelectLast()
         eventPlayer.checkpoint_moved = false
 
@@ -295,21 +295,20 @@ rule "General | Match time":
     pauseMatchTime()
     wait()
     TimeRemaining = 265
-    while TimeRemaining or hostPlayer.editor_saveCache:
+    while TimeRemaining or hostPlayer.editor_on:
         wait(60)
-        if not hostPlayer.editor_saveCache:
-            TimeRemaining--
-            if CompMode:
-                CompTime--
-                if not CompTime:
-                    bigMessage(true[0],"时间到了" checkCN "time's up")
-                    getAllPlayers().comp_done = true
-                    stopChasingVariable(getAllPlayers().timer_normal)
-                    #getAllPlayers().disableRespawn()
-                    getAllPlayers().setDamageReceived(100)
-                    kill(getAllPlayers(), null)
-                    #wait(0.032)
-                    #LeaderBoardRemake = true #async(CreateLeaderboard(), AsyncBehavior.RESTART)
+        TimeRemaining--
+        if CompMode:
+            CompTime--
+            if not CompTime:
+                bigMessage(true[0],"时间到了" checkCN "time's up")
+                getAllPlayers().comp_done = true
+                stopChasingVariable(getAllPlayers().timer_normal)
+                #getAllPlayers().disableRespawn()
+                getAllPlayers().setDamageReceived(100)
+                kill(getAllPlayers(), null)
+                #wait(0.032)
+                #LeaderBoardRemake = true #async(CreateLeaderboard(), AsyncBehavior.RESTART)
 
     bigMessage(true[0], "房间已达最大持续时间, 即将重启" checkCN "maximum lobby time elapsed, restarting")
     wait(5)

--- a/genji.opy
+++ b/genji.opy
@@ -435,8 +435,8 @@ rule "General | Ground: Traces, Arrive, & Reset":
         if len(CheckpointPositions[eventPlayer.checkpoint_current]) > 1:# teleport cps
             CheckpointFailReset()
 
-        if eventPlayer.timer_splitDisplay != -Math.INFINITY:
-            eventPlayer.timer_splitDisplay =  (eventPlayer.timer_practice if eventPlayer.toggle_practice else eventPlayer.timer_normal) - eventPlayer.timer_split
+        if eventPlayer.timer_splitDisplay > -Math.INFINITY:
+            eventPlayer.timer_splitDisplay = (eventPlayer.timer_practice if eventPlayer.toggle_practice else eventPlayer.timer_normal) - eventPlayer.timer_split
         wait()
         playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
         playEffect(eventPlayer if CompMode or eventPlayer.toggle_invisible else true, DynamicEffect.RING_EXPLOSION, Color.SKY_BLUE, CheckpointPositions[eventPlayer.checkpoint_current] + vect(0, 1.5, 0), 4)

--- a/genji.opy
+++ b/genji.opy
@@ -211,7 +211,7 @@ rule "General | Setup & Variables":
 
     # prevent same color lock orbs
     if ColorConfig[Customize.orb_normal] == ColorConfig[Customize.orb_lock]:
-        ColorConfig[Customize.orb_lock] = Color.GREEN  if ColorConfig[Customize.orb_normal] == Color.ORANGE else Color.ORANGE
+        ColorConfig[Customize.orb_lock] = Color.GREEN if ColorConfig[Customize.orb_normal] == Color.ORANGE else Color.ORANGE
 
     # prevent same color bhop/climb used/unused
     if ColorConfig[Customize.bhopclimb_available] == ColorConfig[Customize.bhopclimb_used]:
@@ -225,16 +225,8 @@ rule "General | Setup & Variables":
     #SavePauseEnabled = []
     SaveElapsed = []
 
-    #$$
-    if not BladeEnabledCheckpoints and len(BladeEnabledCheckpoints) == 1:
-        BladeEnabledCheckpoints = [0]
-    else:
-        BladeEnabledCheckpoints = BladeEnabledCheckpoints if len([i for i in BladeEnabledCheckpoints if i != -1 and i != [] ]) and BladeEnabledCheckpoints else []
-
-    if not DashEnabledCheckpoints and len(DashEnabledCheckpoints) == 1:
-        DashEnabledCheckpoints = [0]
-    else:
-        DashEnabledCheckpoints =  DashEnabledCheckpoints if len([i for i in DashEnabledCheckpoints if i != -1 and i != [] ]) and DashEnabledCheckpoints else  []
+    BladeEnabledCheckpoints = [i for i in BladeEnabledCheckpoints if i + false >= 0] if len(BladeEnabledCheckpoints) else []
+    DashEnabledCheckpoints = [i for i in DashEnabledCheckpoints if i + false >= 0] if len(DashEnabledCheckpoints) else []
 
     BouncePadCheckpoints = BouncePadCheckpoints if len(BouncePadCheckpoints) else []
     CheckpointPositions = CheckpointPositions if len(CheckpointPositions) else []

--- a/genji.opy
+++ b/genji.opy
@@ -65,16 +65,16 @@ def UpdateCache():
 
     if eventPlayer != hostPlayer or not eventPlayer.editor_on: return
     EditUpdateSelectedIds()
-    destroyEffect(eventPlayer.editor_hitboxEffect)
-    createEffect(eventPlayer if eventPlayer.editor_hitboxToggle else null, Effect.SPHERE, Color.WHITE, CheckpointPositions[eventPlayer.checkpoint_current], cpcircleradius, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
-    eventPlayer.editor_hitboxEffect = getLastCreatedEntity()
-    createEffect(eventPlayer if eventPlayer.editor_hitboxToggle and eventPlayer.checkpoint_notLast else null, Effect.SPHERE, Color.WHITE, CheckpointPositions[eventPlayer.checkpoint_current + 1], cpcircleradius, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
-    eventPlayer.editor_hitboxEffect.append(getLastCreatedEntity())
-    eventPlayer.editor_bounceIndex = [e for e in [(i if e2 == eventPlayer.checkpoint_current else -1) for e2, i in BouncePadCheckpoints] if e >=0]
-    eventPlayer.editor_killIndex = [e for e in [(i if e2 == eventPlayer.checkpoint_current else -1) for e2, i in KillballCheckpoints] if e >=0]
-    if eventPlayer.checkpoint_moved:
+    destroyEffect(hostPlayer.editor_hitboxEffect)
+    createEffect(hostPlayer if hostPlayer.editor_hitboxToggle else null, Effect.SPHERE, Color.WHITE, CheckpointPositions[hostPlayer.checkpoint_current], cpcircleradius, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    hostPlayer.editor_hitboxEffect = getLastCreatedEntity()
+    createEffect(hostPlayer if hostPlayer.editor_hitboxToggle and hostPlayer.checkpoint_notLast else null, Effect.SPHERE, Color.WHITE, CheckpointPositions[hostPlayer.checkpoint_current + 1], cpcircleradius, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    hostPlayer.editor_hitboxEffect.append(getLastCreatedEntity())
+    hostPlayer.editor_bounceIndex = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in BouncePadCheckpoints] if e >=0]
+    hostPlayer.editor_killIndex = [e for e in [(i if e2 == hostPlayer.checkpoint_current else -1) for e2, i in KillballCheckpoints] if e >=0]
+    if hostPlayer.checkpoint_moved:
         EditorSelectLast()
-        eventPlayer.checkpoint_moved = false
+        hostPlayer.checkpoint_moved = false
 
 def DeleteSave():
     @Name "General | SUB Delete Save"
@@ -258,7 +258,7 @@ rule "General | Setup & Variables":
     BanDead = [i for i in BanDead if i + false >= 0] if len(BanDead) else []
     BanCreate = [i for i in BanCreate if i + false >= 0] if len(BanCreate) else []
     BanMulti = [i for i in BanMulti if i + false >= 0] if len(BanMulti) else []
-    BanTriple = null #[i for i in BanTriple if i + false >= 0] if len(BanTriple) > 0 else [] # legacy code, now auto sets it to null to save space
+    #BanTriple = [i for i in BanTriple if i + false >= 0] if len(BanTriple) else [] # legacy code, now auto sets it to null to save space
     BanStand = [i for i in BanStand if i + false >= 0] if len(BanStand) else []
     BanSaveDouble = BanSaveDouble if len(BanSaveDouble) else []
     BanDjump = BanDjump if len(BanDjump) else []

--- a/genji.opy
+++ b/genji.opy
@@ -247,6 +247,7 @@ rule "General | Setup & Variables":
     CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else []
 
     LeaderBoardFull = []
+    LeaderBoardRemake = false
     TitleData = null
     HintCp = []
     HintText = []

--- a/huds.opy
+++ b/huds.opy
@@ -372,10 +372,11 @@ rule "Huds | Each Player":
 
 def UpdateTitle():
     @Name "Huds | SUB Update Title"
-    if CompMode or eventPlayer.editor_on or not (len(TitleData) and eventPlayer.checkpoint_current in TitleData[0]) or eventPlayer.toggle_practice:
+    if CompMode or eventPlayer.editor_on or not (len(TitleData) and eventPlayer.checkpoint_current in TitleData[0]):# or eventPlayer.toggle_practice:
         return
     destroyInWorldText(eventPlayer.cache_titleHud)
-    createInWorldText((not eventPlayer.toggle_invisible)[0],TitleData[1][TitleData[0].index(eventPlayer.checkpoint_current)], eventPlayer,1.1,Clip.SURFACES, WorldTextReeval.VISIBILITY_AND_POSITION, TitleData.last()[TitleData[0].index(eventPlayer.checkpoint_current)], SpecVisibility.DEFAULT)
+    createInWorldText((not eventPlayer.toggle_invisible)[0],TitleData[1][TitleData[0].index(eventPlayer.checkpoint_current)], eventPlayer, 1.1,
+        Clip.SURFACES, WorldTextReeval.VISIBILITY_AND_POSITION, TitleData.last()[TitleData[0].index(eventPlayer.checkpoint_current)], SpecVisibility.DEFAULT)
     eventPlayer.cache_titleHud = getLastCreatedText()
 
 rule "Huds | Addons":

--- a/huds.opy
+++ b/huds.opy
@@ -87,7 +87,7 @@ rule "Huds | Global Localplayer":
         "移动键 ◀ ▶ | 预览其他\n移动键 ◀ ▶ | 修改间距 \n视角移动 | 调整浏览视角"
         checkCN
         "Walk ◀ ▶ | preview others\nWalk ▲ ▼ | modify zoom\nAim | change preview angle",
-        HudPosition.TOP, HO.com_previewsub, ColorConfig[Customize.command_highlight], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+        HudPosition.TOP, HO.com_previewsub, ColorConfig[Customize.command_highlight], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.NEVER)
     #HudStoreEdit.append(getLastCreatedText())
 
 

--- a/huds.opy
+++ b/huds.opy
@@ -81,14 +81,14 @@ rule "Huds | Global Localplayer":
         checkCN
         "Hold {0} + {1} | Preview cp".format(buttonString(Button.PRIMARY_FIRE),buttonString(Button.SECONDARY_FIRE)),
         HudPosition.RIGHT, HO.com_preview, evalOnce(ColorConfig[Customize.command_highlight]) if localPlayer.preview_array1 else evalOnce(ColorConfig[Customize.command_normal]), HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
-    HudStoreEdit.append(getLastCreatedText())
+    #HudStoreEdit.append(getLastCreatedText())
 
-    hudSubheader(localPlayer if localPlayer.preview_array1 and localPlayer.toggle_guide else null,
+    hudSubheader(true if localPlayer.preview_array1 and localPlayer.toggle_guide else null,
         "移动键 ◀ ▶ | 预览其他\n移动键 ◀ ▶ | 修改间距 \n视角移动 | 调整浏览视角"
         checkCN
         "Walk ◀ ▶ | preview others\nWalk ▲ ▼ | modify zoom\nAim | change preview angle",
         HudPosition.TOP, HO.com_previewsub, ColorConfig[Customize.command_highlight], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    HudStoreEdit.append(getLastCreatedText())
+    #HudStoreEdit.append(getLastCreatedText())
 
 
     hudSubtext(localPlayer,

--- a/huds.opy
+++ b/huds.opy
@@ -92,7 +92,7 @@ rule "Huds | Global Localplayer":
 
 
     hudSubtext(localPlayer,
-        [] if localPlayer.timer_splitDisplay == -Math.INFINITY or localPlayer.toggle_spectate else(
+        [] if localPlayer.timer_splitDisplay <= -Math.INFINITY or localPlayer.toggle_spectate else(
             ("单关用时 {0}" LeftAlign96.format(localPlayer.timer_splitDisplay)
             checkCN
             "Split: {0}" LeftAlign96.format(localPlayer.timer_splitDisplay))),

--- a/huds.opy
+++ b/huds.opy
@@ -83,7 +83,7 @@ rule "Huds | Global Localplayer":
         HudPosition.RIGHT, HO.com_preview, evalOnce(ColorConfig[Customize.command_highlight]) if localPlayer.preview_array1 else evalOnce(ColorConfig[Customize.command_normal]), HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT)
     #HudStoreEdit.append(getLastCreatedText())
 
-    hudSubheader(true if localPlayer.preview_array1 and localPlayer.toggle_guide else null,
+    hudSubheader((localPlayer.preview_array1 and localPlayer.toggle_guide)[0],
         "移动键 ◀ ▶ | 预览其他\n移动键 ◀ ▶ | 修改间距 \n视角移动 | 调整浏览视角"
         checkCN
         "Walk ◀ ▶ | preview others\nWalk ▲ ▼ | modify zoom\nAim | change preview angle",
@@ -100,18 +100,14 @@ rule "Huds | Global Localplayer":
     HudStoreEdit.append(getLastCreatedText())
 
     if len(CpHudText): # text per checkpoint  text per cp each
-        hudText(localPlayer,
-            CpHudText[CpHudCp.index(localPlayer.checkpoint_current)]
-            if localPlayer.checkpoint_current in CpHudCp and localPlayer.toggle_guide else [],
-            ("(文本已隐藏)" checkCN "(text hidden)" if localPlayer.checkpoint_current in CpHudCp and not localPlayer.toggle_guide else []),
-            null,
+        hudText((localPlayer.checkpoint_current in CpHudCp and localPlayer.toggle_guide)[0],
+            CpHudText[CpHudCp.index(localPlayer.checkpoint_current)],
+            null, null,
             HudPosition.TOP, HO.add_custommsg1, Color.BLUE, Color.BLUE, Color.BLUE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
 
     if len(CpIwtText):
-        createInWorldText(
-            localPlayer,
-            CpIwtText[CpIwtCp.index(localPlayer.checkpoint_current)]
-            if localPlayer.checkpoint_current in CpIwtCp else [],
+        createInWorldText(localPlayer.checkpoint_current in CpIwtCp,
+            CpIwtText[CpIwtCp.index(localPlayer.checkpoint_current)],
             CpIwtPos[CpIwtCp.index(localPlayer.checkpoint_current)],
             2, Clip.SURFACES, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, CpIwtColor, SpecVisibility.DEFAULT)
 

--- a/huds.opy
+++ b/huds.opy
@@ -209,6 +209,7 @@ rule "Huds | Global Localplayer":
 
 rule "Huds | Leaderboard": # for global instead of tied to player
     @Condition LeaderBoardRemake
+    @Condition LeaderBoardFull != []
     wait() # account for delay in completion
     while len(LeaderBoardHuds):
         destroyHudText(LeaderBoardHuds[0])

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -93,16 +93,16 @@ rule "Mechanic | Jump":
     #@Condition eventPlayer.skill_usedBhop == false
     @Condition eventPlayer.isJumping()
     eventPlayer.skill_usedBhop = true
-    if eventPlayer.skill_countJumps: #Bhop
+    if eventPlayer.skill_usedHop: #Bhop
         smallMessage(eventPlayer,"   小跳已用" checkCN "   Bhop")
     else: #Hop
-        eventPlayer.skill_countJumps = true
+        eventPlayer.skill_usedHop = true
 
 rule "Mechanic | Before Bhop":
     @Event eachPlayer
-    @Condition eventPlayer.skill_countJumps == null
+    @Condition eventPlayer.skill_usedHop == null
     @Condition eventPlayer.isOnGround() == false
-    eventPlayer.skill_countJumps = true
+    eventPlayer.skill_usedHop = true
 
 rule "Mechanic | Bhop count for stand ban":
     @Event eachPlayer
@@ -136,7 +136,7 @@ rule "Mechanic | Create Bhop":
 rule "Mechanic | Ground Reset":
     @Event eachPlayer
     @Condition eventPlayer.isOnGround()
-    eventPlayer.skill_countJumps = null
+    eventPlayer.skill_usedHop = null
     eventPlayer.skill_usedClimb = false
     eventPlayer.skill_countMulti = null
     eventPlayer.skill_countCreates = null

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -67,14 +67,14 @@ rule "Mechanic | Dash":
     @Condition eventPlayer.isUsingAbility1()
     async(CheckDash(), AsyncBehavior.RESTART)
 
-rule "Mechanic | Player on the wall":
+rule "Mechanic | On Wall":
     @Event eachPlayer
     #This rule is also linked to the determination of wall climbing, please do not close/delete
     @Condition eventPlayer.isOnWall()
     @Condition eventPlayer.isHoldingButton(Button.JUMP)
     eventPlayer.skill_usedClimb = true
 
-rule "Mechanic | Using Emote":
+rule "Mechanic | Emote":
     @Event eachPlayer
     @Condition eventPlayer.isCommunicatingEmote() == true
     eventPlayer.skill_usedBhop = false
@@ -98,7 +98,7 @@ rule "Mechanic | Jump":
     else: #Hop
         eventPlayer.skill_usedHop = true
 
-rule "Mechanic | Before Bhop":
+rule "Mechanic | No Jump":
     @Event eachPlayer
     @Condition eventPlayer.skill_usedHop == null
     @Condition eventPlayer.isOnGround() == false

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -9,14 +9,10 @@ def CheckUlt(): # checks if ult should be turned on
         eventPlayer.setUltCharge(0) # for dash start etc you can be away from cp so the keep charge triggers
     
     eventPlayer.disallowButton(Button.ULTIMATE) # make sure the button cant be pressed until the entire rule ends even if it restarts
-    #if eventPlayer.ult_cd_global > 0: # global cooldown construction that works even when rule is reset
-    if eventPlayer.skill_ultCd > getTotalTimeElapsed():
-        #waitUntil(not eventPlayer.ult_cd_global, true)
+    if eventPlayer.skill_ultCd > getTotalTimeElapsed(): # global cooldown that works even when rule is reset
         wait(eventPlayer.skill_ultCd - getTotalTimeElapsed())
     else:
-        #eventPlayer.ult_cd_global = 1 # this number doesnt matter because its a duration chase
-        #chase(eventPlayer.ult_cd_global, 0, duration=0.36, ChaseReeval.NONE) # duration = the cooldown
-        eventPlayer.skill_ultCd = getTotalTimeElapsed() + 0.36
+        eventPlayer.skill_ultCd = getTotalTimeElapsed() + 0.36 # Set cooldown
 
     if eventPlayer.isUsingUltimate():
         waitUntil(not eventPlayer.isUsingUltimate(), 2)
@@ -32,7 +28,7 @@ def CheckUlt(): # checks if ult should be turned on
         wait()        
         eventPlayer.setUltEnabled(true)
         eventPlayer.setUltCharge(100)
-    elif distance(eventPlayer, CheckpointPositions[eventPlayer.checkpoint_current].last() ) <= 2 or eventPlayer.getUltCharge() < 100: # used to be just else, but have to deal with multi ult orbs
+    elif distance(eventPlayer, CheckpointPositions[eventPlayer.checkpoint_current].last()) <= 2 or eventPlayer.getUltCharge() < 100: # used to be just else, but have to deal with multi ult orbs
         eventPlayer.setUltEnabled(false)
         eventPlayer.setUltCharge(0)
 

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -67,32 +67,11 @@ rule "Mechanic | Dash":
     @Condition eventPlayer.isUsingAbility1()
     async(CheckDash(), AsyncBehavior.RESTART)
 
-rule "Mechanic | Jump":
-    @Event eachPlayer
-    @Condition eventPlayer.isHoldingButton(Button.JUMP)
-    @Condition eventPlayer.skill_countJumps != 2
-    eventPlayer.skill_countJumps += 1
-
-rule "Mechanic | In the air":
-    @Event eachPlayer
-    @Condition eventPlayer.skill_countJumps == null
-    @Condition eventPlayer.isInAir() 
-    eventPlayer.skill_countJumps = 1
-
-/* Remove this rule? */
-rule "Mechanic | Triple jump":
-    @Event eachPlayer
-    @Condition eventPlayer.skill_countJumps == 1
-    # actually just checks if you been in the air for at least 0.1 seconds
-    wait(0.1, Wait.ABORT_WHEN_FALSE)
-    eventPlayer.skill_countJumps = 2
-
 rule "Mechanic | Player on the wall":
     @Event eachPlayer
     #This rule is also linked to the determination of wall climbing, please do not close/delete
     @Condition eventPlayer.isOnWall()
     @Condition eventPlayer.isHoldingButton(Button.JUMP)
-    eventPlayer.skill_countJumps = 2
     eventPlayer.skill_usedClimb = true
 
 rule "Mechanic | Using Emote":
@@ -109,13 +88,21 @@ rule "Mechanic | Using Emote":
         wait()
         CheckpointFailReset()
 
-rule "Mechanic | Bhop":
+rule "Mechanic | Jump":
     @Event eachPlayer
-    @Condition eventPlayer.skill_usedBhop == false
+    #@Condition eventPlayer.skill_usedBhop == false
     @Condition eventPlayer.isJumping()
     eventPlayer.skill_usedBhop = true
-    if eventPlayer.skill_countJumps > 1:
+    if eventPlayer.skill_countJumps: #Bhop
         smallMessage(eventPlayer,"   小跳已用" checkCN "   Bhop")
+    else: #Hop
+        eventPlayer.skill_countJumps = true
+
+rule "Mechanic | Before Bhop":
+    @Event eachPlayer
+    @Condition eventPlayer.skill_countJumps == null
+    @Condition eventPlayer.isOnGround() == false
+    eventPlayer.skill_countJumps = true
 
 rule "Mechanic | Bhop count for stand ban":
     @Event eachPlayer
@@ -125,7 +112,6 @@ rule "Mechanic | Bhop count for stand ban":
     if eventPlayer.skill_countBhops > 1 and not eventPlayer.toggle_invincible:   
         smallMessage(eventPlayer, "   站卡 ♠ 已禁用!" checkCN "   Stand createBhop ♠ is banned!")
         CheckpointFailReset()
-        return
 
 rule "Mechanic | Create Bhop":
     # Credit: Githuboy#5249
@@ -135,21 +121,17 @@ rule "Mechanic | Create Bhop":
     @Condition eventPlayer.isInAir()
     @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
     @Condition eventPlayer.isJumping() == false
-    
     eventPlayer.skill_usedBhop = false
-    if eventPlayer.lockState: # prevent restart from giving messsage, but stil allow it to become green
-        return
+    if eventPlayer.lockState: return # prevent restart from giving messsage, but stil allow it to become green
 
     if eventPlayer.ban_create and not eventPlayer.toggle_invincible:
         smallMessage(eventPlayer, "   卡小 ♂ 已禁用!" checkCN "   Create Bhop ♂ is banned!")
         CheckpointFailReset()
-        return
-    
-    if eventPlayer.ban_standcreate and eventPlayer.skill_countBhops > null:
-        eventPlayer.skill_countBhops--
-
-    eventPlayer.skill_countCreates++
-    smallMessage(eventPlayer, "   success!" checkCN "   Bhop has been created!")    
+    else:
+        if eventPlayer.ban_standcreate and eventPlayer.skill_countBhops > null:
+            eventPlayer.skill_countBhops--
+        eventPlayer.skill_countCreates++
+        smallMessage(eventPlayer, "   success!" checkCN "   Bhop has been created!")    
 
 rule "Mechanic | Ground Reset":
     @Event eachPlayer
@@ -160,10 +142,11 @@ rule "Mechanic | Ground Reset":
     eventPlayer.skill_countCreates = null
     eventPlayer.skill_countBhops = null
     eventPlayer.skill_usedDouble = null
+    /*
     wait()
-    if (eventPlayer.skill_countJumps or eventPlayer.skill_usedClimb) and eventPlayer.isOnGround():
-        goto RULE_START
-    #eventPlayer.skill_usedBhop = true
+    if RULE_CONDITION: goto RULE_START
+    #if (eventPlayer.skill_countJumps or eventPlayer.skill_usedClimb) and eventPlayer.isOnGround(): goto RULE_START
+    #eventPlayer.skill_usedBhop = true*/
 
 rule "Mechanic | Bhop Reset":
     @Event eachPlayer
@@ -197,14 +180,13 @@ rule "Mechanic | Multiclimb":
     @Condition eventPlayer.isOnWall()
     @Condition eventPlayer.isHoldingButton(Button.JUMP) == false
     @Condition eventPlayer.skill_usedClimb == false
-    
     wait()
     if eventPlayer.isOnWall() and not eventPlayer.isHoldingButton(Button.JUMP):
-        eventPlayer.skill_countJumps = 2
+        #AutoClimb used
         eventPlayer.skill_usedClimb = true
     else:
         if eventPlayer.ban_multi and eventPlayer.checkpoint_notLast and not eventPlayer.toggle_invincible:
-            smallMessage(eventPlayer, "    蹭留 ∞ 已禁用!" checkCN "   Multiclimb ∞ is banned!")
+            smallMessage(eventPlayer, "   蹭留 ∞ 已禁用!" checkCN "   Multiclimb ∞ is banned!")
             CheckpointFailReset() 
         else:
             eventPlayer.skill_countMulti += 1

--- a/settings.opy
+++ b/settings.opy
@@ -3,7 +3,7 @@
 settings {
     "main": {
         "modeName": "Genji Parkour - 源氏跑酷 - " + versionhere,
-        "description": "\n◀ The Official Genji Parkour Editor ▶\nCode: 54CRY\nAdapted by: LulledLion, FishoFire, Nebula\n" + versionhere
+        "description": "\n\n\n◀ The Official Genji Parkour Editor ▶\nCode: 54CRY\nAdapted by: LulledLion, FishoFire, Nebula\n" + versionhere
         #"description": "  ~ The Official Genji Parkour Editor ~\nCode: 54CRY\nAdapted by: LulledLion#1133 FishoFire#2431 nebula#11571",
     },
     "lobby": {

--- a/settings.opy
+++ b/settings.opy
@@ -2,8 +2,8 @@
 # code 代码
 settings {
     "main": {
-        "modeName": "Genji Parkour - 源氏跑酷 - " + versionhere,
-        "description": "\n\n\n◀ The Official Genji Parkour Editor ▶\nCode: 54CRY\nAdapted by: LulledLion, FishoFire, Nebula\n" + versionhere
+        "modeName": f"Genji Parkour - 源氏跑酷 - {versionhere}",
+        "description": f"\n\n\n◀ The Official Genji Parkour Editor ▶\nCode: 54CRY\nAdapted by: LulledLion, FishoFire, Nebula\n{versionhere}"
         #"description": "  ~ The Official Genji Parkour Editor ~\nCode: 54CRY\nAdapted by: LulledLion#1133 FishoFire#2431 nebula#11571",
     },
     "lobby": {

--- a/settings.opy
+++ b/settings.opy
@@ -44,48 +44,48 @@ settings {
             "enableSelfInitiatedRespawn": false
         },
         /*"assault": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         "bountyHunter": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },
         /*"clash": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         "ctf": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },
         /*"control": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         /*"escort": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         "elimination": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },
         /*"flashpoint": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         /*"hybrid": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
         "practiceRange": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },
         /*"push": {
-            "enabled": usePerks,
-            "enablePerks": false
+            "enabled": false,
+            "enablePerks": usePerks
         },*/
     },
     "heroes": {

--- a/test-maps/togglescript.js
+++ b/test-maps/togglescript.js
@@ -25,7 +25,8 @@ if (x == 0){
     20: "test-maps/rialtofisho.opy", // my rialto
     21: "test-maps/2cpmulti.opy", // 2 cp multi
     22: "test-maps/generaltest.opy",
-    23: "test-maps/bandoublejump.opy" // lulledlion's map
+    23: "test-maps/bandoublejump.opy", // lulledlion's map
+    24: "test-maps/puzzle.opy", // lulledlion's map
     }[x]
 
     selectedmap = {
@@ -51,7 +52,8 @@ if (x == 0){
     20: "rialto",
     21: "workshopChamber",
     22: "workshopChamber",
-    23: "lijiangNightMarket"
+    23: "lijiangNightMarket",
+    24: "hanamura",
     }[x]
 
     x = '#!define testData #!include "'+ datafiles + '"\n #!define selectedmap "' + selectedmap + '"' + '\n #!define editoron false\n'

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -579,6 +579,8 @@ fixed:
        * Press Jump to move Up
        * Press Crouch to move Down
    * Reported by `@bioslet` +5xp
+### Commands
+ - Fixed hiding Split Display
 ### Addon
  - Fixed Group Up from causing extra movement
    * Reported by `@bioslet` +5xp

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -567,7 +567,19 @@ fixed:
    * Reported by `@hello_5702` & `@bioslet` +5xp
  - Prevent immediate upwards movement of objects
 
- # 1.10.
-### Objects
- - Fixed upwards movement prevention from forcing moving up objects
-   * Reported by `@n1troh`
+# 1.10.3F
+### Editor
+ - Fixed objects colors upon exporting
+   * Reported by `@CoralMage` +5xp
+ - Fixed objects upwards movement prevention
+   * Reported by `@n1troh` +5xp
+ - Fly mode
+   * Movement disabled when changes being made
+     - Move checkpoint control scheme
+       * Press Jump to move Up
+       * Press Crouch to move Down
+   * Reported by `@bioslet` +5xp
+### Addon
+ - Fixed Group Up from causing extra movement
+   * Reported by `@bioslet` +5xp
+ - Fixed Triple Jump to restart when climbing or dashing after landing

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -566,3 +566,8 @@ fixed:
  - Fixed cancel placement from corrupting map object data
    * Reported by `@hello_5702` & `@bioslet` +5xp
  - Prevent immediate upwards movement of objects
+
+ # 1.10.
+### Objects
+ - Fixed upwards movement prevention from forcing moving up objects
+   * Reported by `@n1troh`

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -593,4 +593,4 @@ fixed:
 ### Other
  - Fixed bhop message for jumping when jump is double pressed
  - Fixed Null player completion with old map data
-   * Reported by `@zxzpkcxcc`
+   * Reported by `@zxzpkcxcc` +5xp

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -592,3 +592,5 @@ fixed:
    * Reported by `@kuma0997` +5xp
 ### Other
  - Fixed bhop message for jumping when jump is double pressed
+ - Fixed Null player completion with old map data
+   * Reported by `@zxzpkcxcc`

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -586,5 +586,5 @@ fixed:
  - Fixed Group Up from causing extra movement
    * Reported by `@bioslet` +5xp
  - Fixed Triple Jump to restart when climbing or dashing after landing
- - Missing Addon Texts [FIXED]
+ - Fixed missing Addon Texts
    * Reported by `@kuma0997` +5xp

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -590,3 +590,5 @@ fixed:
  - Fixed Triple Jump to restart when climbing or dashing after landing
  - Fixed missing Addon Texts
    * Reported by `@kuma0997` +5xp
+### Other
+ - Fixed bhop message for jumping when jump is double pressed

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -579,9 +579,11 @@ fixed:
        * Press Jump to move Up
        * Press Crouch to move Down
    * Reported by `@bioslet` +5xp
+ - Fixed flipped bounce values on toggle
+   * Reported by `@n1troh` +5xp
 ### Commands
  - Fixed hiding Split Display
- - Fixed 1/0 in preview
+ - Fixed 1/0 in Preview
 ### Addon
  - Fixed Group Up from causing extra movement
    * Reported by `@bioslet` +5xp

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -581,7 +581,10 @@ fixed:
    * Reported by `@bioslet` +5xp
 ### Commands
  - Fixed hiding Split Display
+ - Fixed 1/0 in preview
 ### Addon
  - Fixed Group Up from causing extra movement
    * Reported by `@bioslet` +5xp
  - Fixed Triple Jump to restart when climbing or dashing after landing
+ - Missing Addon Texts [FIXED]
+   * Reported by `@kuma0997` +5xp

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -571,7 +571,7 @@ fixed:
 ### Editor
  - Fixed objects colors upon exporting
    * Reported by `@CoralMage` +5xp
- - Fixed objects upwards movement prevention
+ - Fixed prevention for objects upwards movement
    * Reported by `@n1troh` +5xp
  - Fly mode
    * Movement disabled when changes being made

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -72,3 +72,5 @@ triple jump ban doesnt work on workshop maps anymore
    * Reported by `@kuma0997`
  - Flipped editor bounce values
    * Reported by `@n1troh`
+ - Null player completion with old map data [FIXED]
+   * Reported by `@zxzpkcxcc`

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -63,7 +63,7 @@ triple jump ban doesnt work on workshop maps anymore
    * Reported by `@n1troh`
  - Colors revert to blue upon export [FIXED]
    * Reported by `@CoralMage`
- - Group Up addon causes weird impulse
+ - Group Up addon causing extra movement [FIXED]
    * Reported by `@bioslet`
  - Missing huds [USER ERROR]
    * Reported by `@hello_5702`

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -70,3 +70,5 @@ triple jump ban doesnt work on workshop maps anymore
    * Skill issue
  - Missing Addon Texts [FIXED]
    * Reported by `@kuma0997`
+ - Flipped editor bounce values
+   * Reported by `@n1troh`

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -59,5 +59,12 @@ triple jump ban doesnt work on workshop maps anymore
    * Reported by `@Shade` & `@CoralMage`
  - Leaderboard updates player time to a worse time [FIXED]
    * Reported by `@lostje` & `@bioslet`
- - Move Orb move up prevention forcing move up
+ - Move Orb move up prevention forcing move up [FIXED]
    * Reported by `@n1troh`
+ - Colors revert to blue upon export [FIXED]
+   * Reported by `@CoralMage`
+ - Group Up addon causes weird impulse
+   * Reported by `@bioslet`
+ - Missing huds [USER ERROR]
+   * Reported by `@hello_5702`
+   * Skill issue

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -68,3 +68,5 @@ triple jump ban doesnt work on workshop maps anymore
  - Missing huds [USER ERROR]
    * Reported by `@hello_5702`
    * Skill issue
+ - Missing Addon Texts [FIXED]
+   * Reported by `@kuma0997`

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -59,3 +59,5 @@ triple jump ban doesnt work on workshop maps anymore
    * Reported by `@Shade` & `@CoralMage`
  - Leaderboard updates player time to a worse time [FIXED]
    * Reported by `@lostje` & `@bioslet`
+ - Move Orb move up prevention forcing move up
+   * Reported by `@n1troh`


### PR DESCRIPTION
# 1.10.3F
### Editor
 - Fixed objects colors upon exporting
   * Reported by `@CoralMage` +5xp
 - Fixed prevention for objects upwards movement
   * Reported by `@n1troh` +5xp
 - Fly mode
   * Movement disabled when changes being made
     - Move checkpoint control scheme
       * Press Jump to move Up
       * Press Crouch to move Down
   * Reported by `@bioslet` +5xp
 - Fixed flipped bounce values on toggle
   * Reported by `@n1troh` +5xp
### Commands
 - Fixed hiding Split Display
 - Fixed 1/0 in Preview
### Addons
 - Fixed Group Up from causing extra movement
   * Reported by `@bioslet` +5xp
 - Fixed Triple Jump to restart when climbing or dashing after landing
 - Fixed missing Addon Texts
   * Reported by `@kuma0997` +5xp
### Other
 - Fixed bhop message for jumping when jump is double pressed
 - Fixed Null player completion with old map data
   * Reported by `@zxzpkcxcc` +5xp